### PR TITLE
Update README with Go ref links

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,14 +4,18 @@
   ],
   "go.lintTool": "golangci-lint",
   "cSpell.words": [
+    "codecov",
     "Debugf",
     "FCAPI",
     "FFCAPI",
     "ffresty",
     "fftypes",
+    "httpserver",
     "Hyperledger",
     "Infof",
-    "TLSCA"
+    "runtimes",
+    "TLSCA",
+    "wsclient"
   ],
   "go.testTimeout": "10s"
 }

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
+[![codecov](https://codecov.io/gh/hyperledger/firefly-common/branch/main/graph/badge.svg?token=LUX2I5EU0T)](https://codecov.io/gh/hyperledger/firefly-common)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hyperledger/firefly-common.svg)](https://pkg.go.dev/github.com/hyperledger/firefly-common)
+
 # Hyperledger FireFly Common
 
-Common utilities utilized across FireFly projects
+Common utility modules and interface definitions, used across Hyperledger FireFly microservice runtimes (the Go ones anyway):
 
-- Logging
-- Translation (i18n)
-- Configuration
-- Core types
-- REST Client
-- WebSocket Client
-- HTTP Server
+- FireFly Connector API (FFCAPI) - [pkg/ffcapi](https://pkg.go.dev/github.com/hyperledger/firefly-common/pkg/ffcapi)
+- Logging - [pkg/log](https://pkg.go.dev/github.com/hyperledger/firefly-common/pkg/log)
+- Translation (i18n) - [pkg/i18n](https://pkg.go.dev/github.com/hyperledger/firefly-common/pkg/i18n)
+- Configuration - [pkg/config](https://pkg.go.dev/github.com/hyperledger/firefly-common/pkg/config)
+- Common types - [pkg/fftypes](https://pkg.go.dev/github.com/hyperledger/firefly-common/pkg/fftypes)
+- REST Client - [pkg/ffresty](https://pkg.go.dev/github.com/hyperledger/firefly-common/pkg/ffresty)
+- WebSocket Client - [pkg/wsclient](https://pkg.go.dev/github.com/hyperledger/firefly-common/pkg/wsclient)
+- HTTP Server - [pkg/httpserver](https://pkg.go.dev/github.com/hyperledger/firefly-common/pkg/httpserver)


### PR DESCRIPTION
I noticed that the FFCAPI was missing from the README, and overall it was missing links to the API docs.