### PR TITLE
Do not assume exec output is an array

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,8 +13,10 @@
     "httpserver",
     "Hyperledger",
     "Infof",
+    "Nowarn",
     "runtimes",
     "TLSCA",
+    "Warnf",
     "wsclient"
   ],
   "go.testTimeout": "10s"

--- a/pkg/ffcapi/exec_query.go
+++ b/pkg/ffcapi/exec_query.go
@@ -36,7 +36,7 @@ type ExecQueryRequest struct {
 
 type ExecQueryResponse struct {
 	ResponseBase
-	Outputs []*fftypes.JSONAny `json:"outputs"`
+	Outputs *fftypes.JSONAny `json:"outputs"`
 }
 
 const RequestTypeExecQuery RequestType = "exec_query"

--- a/pkg/ffcapi/exec_query_test.go
+++ b/pkg/ffcapi/exec_query_test.go
@@ -26,13 +26,17 @@ import (
 
 func TestExecQueryOK(t *testing.T) {
 	a, cancel := newTestClient(t, &ExecQueryResponse{
-		Outputs: []*fftypes.JSONAny{fftypes.JSONAnyPtr("{}")},
+		Outputs: fftypes.JSONAnyPtr(`[{
+			"name": "return",
+			"value": "value1"
+		}]`),
 	})
 	defer cancel()
 	res, reason, err := a.ExecQuery(context.Background(), &ExecQueryRequest{})
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
-	assert.Len(t, res.Outputs, 1)
+	assert.Len(t, res.Outputs.JSONObjectArray(), 1)
+	assert.Equal(t, "value1", res.Outputs.JSONObjectArray()[0].GetString("value"))
 }
 
 func TestExecQueryFail(t *testing.T) {

--- a/pkg/fftypes/jsonany.go
+++ b/pkg/fftypes/jsonany.go
@@ -128,7 +128,7 @@ func (h *JSONAny) JSONObjectOk(noWarn ...bool) (JSONObject, bool) {
 	return jo, err == nil
 }
 
-// JSONObject attempts to de-serailize the contained structure as a JSON Object (map)
+// JSONObject attempts to de-serialize the contained structure as a JSON Object (map)
 // Safe and will never return nil
 // Will return an empty object if the type is array, string, bool, number etc.
 func (h *JSONAny) JSONObject() JSONObject {
@@ -141,6 +141,28 @@ func (h *JSONAny) JSONObject() JSONObject {
 func (h *JSONAny) JSONObjectNowarn() JSONObject {
 	jo, _ := h.JSONObjectOk(true)
 	return jo
+}
+
+func (h *JSONAny) JSONObjectArrayOk(noWarn ...bool) (JSONObjectArray, bool) {
+	var joa JSONObjectArray
+	b := []byte{}
+	if h != nil {
+		b = []byte(*h)
+	}
+	err := json.Unmarshal(b, &joa)
+	if err != nil {
+		if len(noWarn) == 0 || !noWarn[0] {
+			log.L(context.Background()).Warnf("Unable to deserialize as JSON object array: %s", string(b))
+		}
+		joa = JSONObjectArray{}
+	}
+	return joa, err == nil
+}
+
+// JSONObject attempts to de-serialize the contained structure an array of JSON objects
+func (h *JSONAny) JSONObjectArray() JSONObjectArray {
+	joa, _ := h.JSONObjectArrayOk()
+	return joa
 }
 
 // Value ensures we write null to the DB for null values

--- a/pkg/fftypes/jsonany_test.go
+++ b/pkg/fftypes/jsonany_test.go
@@ -132,6 +132,18 @@ func TestScan(t *testing.T) {
 
 }
 
+func TestJSONAnyToJSONObjectArray(t *testing.T) {
+
+	var h JSONAny
+
+	assert.NoError(t, h.Scan(`[{"some": "stuff"}]`))
+	assert.Equal(t, "stuff", h.JSONObjectArray()[0].GetString("some"))
+
+	assert.NoError(t, h.Scan(`{"some": "stuff"}`))
+	assert.Empty(t, h.JSONObjectArray())
+
+}
+
 func TestValue(t *testing.T) {
 
 	var h *JSONAny


### PR DESCRIPTION
The `ExecQueryResponse` (which hasn't been relied upon by any downstream code) had assumed `output` was an array, but in reality it is more likely to be a named key-value map.