### PR TITLE
Add PreTranslatedDescription field to API Route

### DIFF
--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -304,10 +304,15 @@ func (sg *SwaggerGen) AddParam(ctx context.Context, op *openapi3.Operation, in, 
 }
 
 func (sg *SwaggerGen) addRoute(ctx context.Context, doc *openapi3.T, route *Route) {
+	var routeDescription string
 	pi := sg.getPathItem(doc, route.Path)
-	routeDescription := i18n.Expand(ctx, route.Description)
-	if routeDescription == "" && sg.options.PanicOnMissingDescription {
-		log.Panicf(i18n.NewError(ctx, i18n.MsgRouteDescriptionMissing, route.Name).Error())
+	if route.PreTranslatedDescription != "" {
+		routeDescription = route.PreTranslatedDescription
+	} else {
+		routeDescription = i18n.Expand(ctx, route.Description)
+		if routeDescription == "" && sg.options.PanicOnMissingDescription {
+			log.Panicf(i18n.NewError(ctx, i18n.MsgRouteDescriptionMissing, route.Name).Error())
+		}
 	}
 	op := &openapi3.Operation{
 		Description: routeDescription,

--- a/pkg/ffapi/openapi3_test.go
+++ b/pkg/ffapi/openapi3_test.go
@@ -64,8 +64,6 @@ type TestStruct2 struct {
 
 var ExampleDesc = i18n.FFM(language.AmericanEnglish, "TestKey", "Test Description")
 
-// var ExampleConf = i18n.FFC(language.AmericanEnglish, "config.conf.key1", "Test Config Key", "string")
-
 var testRoutes = []*Route{
 	{
 		Name:   "op1",
@@ -378,4 +376,26 @@ func TestPanicOnMissingRouteDescription(t *testing.T) {
 			PanicOnMissingDescription: true,
 		}).Generate(context.Background(), routes)
 	})
+}
+
+func TestPreTranslatedRouteDescription(t *testing.T) {
+	routes := []*Route{
+		{
+			Name:                     "PostTagTest",
+			Path:                     "namespaces/{ns}/example1/test",
+			Method:                   http.MethodPost,
+			JSONInputValue:           func() interface{} { return &TestInOutType{} },
+			JSONOutputValue:          func() interface{} { return &TestInOutType{} },
+			JSONOutputCodes:          []int{http.StatusOK},
+			PreTranslatedDescription: "this is a description",
+		},
+	}
+	swagger := NewSwaggerGen(&Options{
+		Title:   "UnitTest",
+		Version: "1.0",
+		BaseURL: "http://localhost:12345/api/v1",
+	}).Generate(context.Background(), routes)
+	assert.NotNil(t, swagger.Paths["/namespaces/{ns}/example1/test"].Post.RequestBody.Value)
+	description := swagger.Paths["/namespaces/{ns}/example1/test"].Post.Description
+	assert.Equal(t, "this is a description", description)
 }

--- a/pkg/ffapi/routes.go
+++ b/pkg/ffapi/routes.go
@@ -42,6 +42,8 @@ type Route struct {
 	Method string
 	// Description is a message key to a translatable description of the operation
 	Description i18n.MessageKey
+	// PreTranslatedDescription is a string describing the operation - used for programmatically generated routes where a built-in string translation is not available
+	PreTranslatedDescription string
 	// JSONInputValue is a function that returns a pointer to a structure to take JSON input
 	JSONInputValue func() interface{}
 	// JSONInputMask are fields that aren't available for users to supply on input


### PR DESCRIPTION
This PR adds a new field to the API Route struct which is a pre-translated description. This is useful for programmatically generated routes where a translation key will not be present in the code. An example of this is: the description of a custom smart contract function.