### PR TITLE
Allow use of FF object schema generator in custom schema defs for anyOf

### DIFF
--- a/.vscode/configurationCache.log
+++ b/.vscode/configurationCache.log
@@ -1,0 +1,1 @@
+{"buildTargets":["/Users/pbroadhurst/go/bin/golangci-lint","/Users/pbroadhurst/go/bin/mockery","all","build","clean","coverage","coverage.html","deps","firefly-common","go-mod-tidy","lint","mocks","mocks-pkg/httpserver-GoHTTPServer","test"],"launchTargets":[],"customConfigurationProvider":{"workspaceBrowse":{"browsePath":[],"compilerArgs":[]},"fileIndex":[]}}

--- a/.vscode/dryrun.log
+++ b/.vscode/dryrun.log
@@ -1,0 +1,11 @@
+make --dry-run --always-make --keep-going --print-directory
+make: Entering directory `/Users/pbroadhurst/dev/firefly/firefly-common'
+go build ./pkg/*
+ 
+go get ./pkg/*
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+GOGC=20 /Users/pbroadhurst/go/bin/golangci-lint run -v --timeout 5m
+go test ./pkg/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
+go mod tidy
+make: Leaving directory `/Users/pbroadhurst/dev/firefly/firefly-common'
+ 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
   "go.lintTool": "golangci-lint",
   "cSpell.words": [
     "codecov",
+    "Customizer",
     "Debugf",
     "FCAPI",
     "ffapi",

--- a/.vscode/targets.log
+++ b/.vscode/targets.log
@@ -1,0 +1,929 @@
+make all --print-data-base --no-builtin-variables --no-builtin-rules --question
+# GNU Make 3.81
+# Copyright (C) 2006  Free Software Foundation, Inc.
+# This is free software; see the source for copying conditions.
+# There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE.
+
+# This program built for i386-apple-darwin11.3.0
+ 
+
+# Make data base, printed on Sat Jun 18 12:57:15 2022
+
+# Variables
+
+# environment
+VSCODE_GIT_ASKPASS_MAIN = /Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass-main.js
+# automatic
+<D = $(patsubst %/,%,$(dir $<))
+# automatic
+?F = $(notdir $?)
+# environment
+ELECTRON_NO_ATTACH_CONSOLE = 1
+# environment
+VSCODE_LOG_NATIVE = false
+# automatic
+?D = $(patsubst %/,%,$(dir $?))
+# automatic
+@D = $(patsubst %/,%,$(dir $@))
+# automatic
+@F = $(notdir $@)
+# makefile
+CURDIR := /Users/pbroadhurst/dev/firefly/firefly-common
+# makefile
+SHELL = /bin/sh
+# environment
+VSCODE_NLS_CONFIG = {"locale":"en-us","availableLanguages":{},"_languagePackSupport":true}
+# environment
+_ = /usr/bin/make
+# makefile (from `Makefile', line 1)
+MAKEFILE_LIST :=  Makefile
+# environment
+VSCODE_AMD_ENTRYPOINT = vs/workbench/api/node/extensionHostProcess
+# environment
+VSCODE_VERBOSE_LOGGING = true
+# environment
+__CFBundleIdentifier = com.microsoft.VSCode
+# environment
+INFOPATH = /opt/homebrew/share/info:/opt/homebrew/share/info:/opt/homebrew/share/info:/opt/homebrew/share/info:
+# environment
+VSCODE_IPC_HOOK_EXTHOST = /var/folders/tb/b88h058x6675g5g_dkgsy8jm0000gn/T/vscode-ipc-002335cc-6320-43cd-b311-e82f367f7aca.sock
+# environment
+VSCODE_CWD = /Users/pbroadhurst/dev/firefly/firefly-transaction-manager
+# environment
+GOPROXY = https://proxy.golang.org,direct
+# environment
+PATH = /usr/local/go/bin:/opt/homebrew/opt/ruby/bin:/opt/homebrew/opt/gnupg@2.3/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/opt/ruby/bin:/opt/homebrew/opt/gnupg@2.3/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/pbroadhurst/go/bin:/Users/pbroadhurst/go/bin
+# makefile (from `Makefile', line 8)
+CGO_ENABLED = 0
+# environment
+LSCOLORS = Gxfxcxdxbxegedabagacad
+# makefile (from `Makefile', line 4)
+LINT := /Users/pbroadhurst/go/bin/golangci-lint
+# makefile (from `Makefile', line 5)
+ 
+MOCKERY := /Users/pbroadhurst/go/bin/mockery
+# environment
+GOPATH = /Users/pbroadhurst/go
+# environment
+VSCODE_LOG_STACK = false
+# environment
+ELECTRON_RUN_AS_NODE = 1
+# default
+.FEATURES := target-specific order-only second-expansion else-if archives jobserver check-symlink
+# environment
+SSH_AUTH_SOCK = /Users/pbroadhurst/.gnupg/S.gpg-agent.ssh
+# automatic
+%F = $(notdir $%)
+# makefile (from `Makefile', line 3)
+GOBIN := /Users/pbroadhurst/go/bin
+# environment
+VSCODE_PIPE_LOGGING = true
+# environment
+PWD = /Users/pbroadhurst/dev/firefly/firefly-common
+# environment
+HOMEBREW_CELLAR = /opt/homebrew/Cellar
+# environment
+ORIGINAL_XDG_CURRENT_DESKTOP = undefined
+# environment
+MANPATH = /opt/homebrew/share/man:/usr/share/man:/usr/local/share/man:/opt/homebrew/share/man:
+# environment
+GOMODCACHE = /Users/pbroadhurst/go/pkg/mod
+# environment
+HOME = /Users/pbroadhurst
+# default
+MAKEFILEPATH = $(shell /usr/bin/xcode-select -print-path 2>/dev/null || echo /Developer)/Makefiles
+# environment
+VSCODE_CLI = 1
+# makefile (from `Makefile', line 9)
+GOGC = 30
+# environment
+VSCODE_CODE_CACHE_PATH = /Users/pbroadhurst/Library/Application Support/Code/CachedData/4af164ea3a06f701fe3e89a2bcbb421d2026b68f
+# environment
+LOGNAME = pbroadhurst
+# environment
+APPLICATION_INSIGHTS_NO_DIAGNOSTIC_CHANNEL = 1
+# environment
+ZSH = /Users/pbroadhurst/.oh-my-zsh
+# makefile (from `Makefile', line 27)
+define makemock
+mocks: mocks-$(strip $(1))-$(strip $(2))
+mocks-$(strip $(1))-$(strip $(2)): ${MOCKERY}
+	${MOCKERY} --case underscore --dir $(1) --name $(2) --outpkg $(3) --output mocks/$(strip $(3))
+endef
+# environment
+VSCODE_HANDLES_UNCAUGHT_ERRORS = true
+# automatic
+^D = $(patsubst %/,%,$(dir $^))
+# environment
+MAKELEVEL := 0
+# environment
+XPC_FLAGS = 0x0
+# environment
+COLORTERM = truecolor
+# default
+MAKE = $(MAKE_COMMAND)
+# default
+MAKECMDGOALS := all
+# environment
+SHLVL = 7
+# default
+MAKE_VERSION := 3.81
+# environment
+USER = pbroadhurst
+# makefile
+.DEFAULT_GOAL := all
+# environment
+GOROOT = /usr/local/go
+# environment
+LESS = -R
+# automatic
+%D = $(patsubst %/,%,$(dir $%))
+# default
+MAKE_COMMAND := /Library/Developer/CommandLineTools/usr/bin/make
+# environment
+VSCODE_GIT_ASKPASS_EXTRA_ARGS = --ms-enable-electron-run-as-node
+# environment
+TERM_PROGRAM = vscode
+# default
+.VARIABLES := 
+# environment
+TMPDIR = /var/folders/tb/b88h058x6675g5g_dkgsy8jm0000gn/T/
+# automatic
+*F = $(notdir $*)
+# environment
+VSCODE_IPC_HOOK = /Users/pbroadhurst/Library/Application Support/Code/1.68.0-main.sock
+# environment
+VSCODE_GIT_ASKPASS_NODE = /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper
+# makefile
+MAKEFLAGS = Rrqp
+# environment
+MFLAGS = -Rrqp
+# automatic
+*D = $(patsubst %/,%,$(dir $*))
+# environment
+TERM_PROGRAM_VERSION = 1.68.0
+# environment
+XPC_SERVICE_NAME = application.com.microsoft.VSCode.22333126.22333132.DAD532DE-6EF7-4906-A893-EBB00CF3A824
+# environment
+HOMEBREW_PREFIX = /opt/homebrew
+# automatic
++D = $(patsubst %/,%,$(dir $+))
+# automatic
++F = $(notdir $+)
+# environment
+HOMEBREW_REPOSITORY = /opt/homebrew
+# environment
+__CF_USER_TEXT_ENCODING = 0x1F5:0x0:0x0
+# environment
+COMMAND_MODE = unix2003
+# environment
+GIT_ASKPASS = /Applications/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass.sh
+# default
+MAKEFILES := 
+# automatic
+<F = $(notdir $<)
+# makefile (from `Makefile', line 1)
+VGO = go
+# environment
+PAGER = less
+# environment
+LC_ALL = C
+# automatic
+^F = $(notdir $^)
+# default
+SUFFIXES := 
+# default
+.INCLUDE_DIRS = /usr/local/include
+# makefile (from `Makefile', line 2)
+GOFILES := pkg/retry/retry_test.go pkg/retry/retry.go pkg/wsclient/wstestserver.go pkg/wsclient/wsconfig_test.go pkg/wsclient/wsclient_test.go pkg/wsclient/wsclient.go pkg/wsclient/wsconfig.go pkg/config/config.go pkg/config/config_test.go pkg/fftypes/resterror.go pkg/fftypes/uuid_test.go pkg/fftypes/jsonobject.go pkg/fftypes/sizeutils.go pkg/fftypes/config_record.go pkg/fftypes/bigint.go pkg/fftypes/bytetypes_test.go pkg/fftypes/bigint_test.go pkg/fftypes/sizeutils_test.go pkg/fftypes/jsonobjectarray.go pkg/fftypes/timeutils_test.go pkg/fftypes/idutils.go pkg/fftypes/enum_test.go pkg/fftypes/bytetypes.go pkg/fftypes/jsonobject_test.go pkg/fftypes/idutils_test.go pkg/fftypes/uuid.go pkg/fftypes/jsonany_test.go pkg/fftypes/timeutils.go pkg/fftypes/enum.go pkg/fftypes/jsonobjectarray_test.go pkg/fftypes/jsonany.go pkg/httpserver/httpserver_test.go pkg/httpserver/config.go pkg/httpserver/httpserver.go pkg/httpserver/server_cors_test.go pkg/httpserver/server_cors.go pkg/ffresty/config.go pkg/ffresty/ffresty.go pkg/ffresty/ffresty_test.go pkg/log/log.go pkg/log/log_test.go pkg/ffapi/handler.go pkg/ffapi/apirequest.go pkg/ffapi/openapi3_test.go pkg/ffapi/multipart.go pkg/ffapi/swaggerui_test.go pkg/ffapi/routes.go pkg/ffapi/handler_test.go pkg/ffapi/openapi3.go pkg/ffapi/swaggerui.go pkg/i18n/errors_test.go pkg/i18n/en_base_error_messages.go pkg/i18n/messages_test.go pkg/i18n/en_base_messages.go pkg/i18n/en_base_config_descriptions.go pkg/i18n/messages.go pkg/i18n/es/es_base_config_descriptions.go pkg/i18n/errors.go
+# environment
+VSCODE_GIT_IPC_HANDLE = /var/folders/tb/b88h058x6675g5g_dkgsy8jm0000gn/T/vscode-git-1196a4e00d.sock
+# environment
+GPG_TTY = /dev/ttys001
+# environment
+LANG = C
+# environment
+TERM = xterm-256color
+# environment
+VSCODE_PID = 60118
+# variable set hash-table stats:
+# Load=95/1024=9%, Rehash=0, Collisions=4/137=3%
+
+# Pattern-specific Variable Values
+
+# No pattern-specific variable values.
+
+# Directories
+
+# . (device 16777231, inode 14626581): 25 files, no impossibilities.
+
+# 25 files, no impossibilities in 1 directories.
+
+# Implicit Rules
+
+# No implicit rules.
+
+# Files
+
+# Not a target:
+pkg/i18n/en_base_messages.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/i18n/messages_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+/Users/pbroadhurst/go/bin/golangci-lint:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 24):
+	$(VGO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	
+
+# Not a target:
+pkg/fftypes/sizeutils.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/bigint.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+all: build test go-mod-tidy
+#  Command-line target.
+#  Implicit rule search has been done.
+#  File does not exist.
+#  File has been updated.
+#  Needs to be updated (-q is set).
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/3=0%
+
+# Not a target:
+pkg/fftypes/enum_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/jsonobject_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/idutils_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffapi/swaggerui_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+ 
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+go-mod-tidy: .ALWAYS
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 38):
+	$(VGO) mod tidy
+	
+
+# Not a target:
+pkg/i18n/messages.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+deps:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 44):
+	$(VGO) get ./pkg/*
+	
+
+# Not a target:
+pkg/fftypes/jsonobjectarray.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/bytetypes.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/httpserver/server_cors.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+.SUFFIXES:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+
+# Not a target:
+pkg/i18n/en_base_error_messages.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffapi/openapi3_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-18 12:33:26
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+Makefile:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffapi/handler.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-06 11:57:04
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/jsonany_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-24 17:27:37
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+mocks-pkg/httpserver-GoHTTPServer: /Users/pbroadhurst/go/bin/mockery
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 33):
+	/Users/pbroadhurst/go/bin/mockery --case underscore --dir  pkg/httpserver --name             GoHTTPServer --outpkg        httpservermocks --output mocks/httpservermocks
+	
+
+test: deps lint
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 15):
+	$(VGO) test ./pkg/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
+	
+
+# Not a target:
+pkg/wsclient/wsconfig_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+build: firefly-common
+#  Implicit rule search has been done.
+#  File does not exist.
+#  File has been updated.
+#  Needs to be updated (-q is set).
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/3=0%
+
+# Not a target:
+pkg/ffapi/multipart.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/wsclient/wsconfig.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/enum.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/jsonobject.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffresty/config.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/retry/retry_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 17:18:41
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/idutils.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffapi/swaggerui.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/uuid_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/timeutils.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/i18n/errors_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffapi/openapi3.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-18 12:33:26
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/jsonany.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-24 17:27:37
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+.DEFAULT:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+
+# Not a target:
+pkg/wsclient/wsclient.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffresty/ffresty_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/timeutils_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/config/config_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-01 10:44:34
+#  File has been updated.
+#  Successfully updated.
+ 
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/httpserver/httpserver_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/log/log_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+clean:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 42):
+	$(VGO) clean
+	
+
+coverage: test coverage.html
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+
+# Not a target:
+pkg/wsclient/wsclient_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/i18n/en_base_config_descriptions.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 09:18:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+.ALWAYS:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 40):
+	
+
+# Not a target:
+pkg/ffapi/routes.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-18 12:34:32
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+firefly-common: pkg/retry/retry_test.go pkg/retry/retry.go pkg/wsclient/wstestserver.go pkg/wsclient/wsconfig_test.go pkg/wsclient/wsclient_test.go pkg/wsclient/wsclient.go pkg/wsclient/wsconfig.go pkg/config/config.go pkg/config/config_test.go pkg/fftypes/resterror.go pkg/fftypes/uuid_test.go pkg/fftypes/jsonobject.go pkg/fftypes/sizeutils.go pkg/fftypes/config_record.go pkg/fftypes/bigint.go pkg/fftypes/bytetypes_test.go pkg/fftypes/bigint_test.go pkg/fftypes/sizeutils_test.go pkg/fftypes/jsonobjectarray.go pkg/fftypes/timeutils_test.go pkg/fftypes/idutils.go pkg/fftypes/enum_test.go pkg/fftypes/bytetypes.go pkg/fftypes/jsonobject_test.go pkg/fftypes/idutils_test.go pkg/fftypes/uuid.go pkg/fftypes/jsonany_test.go pkg/fftypes/timeutils.go pkg/fftypes/enum.go pkg/fftypes/jsonobjectarray_test.go pkg/fftypes/jsonany.go pkg/httpserver/httpserver_test.go pkg/httpserver/config.go pkg/httpserver/httpserver.go pkg/httpserver/server_cors_test.go pkg/httpserver/server_cors.go pkg/ffresty/config.go pkg/ffresty/ffresty.go pkg/ffresty/ffresty_test.go pkg/log/log.go pkg/log/log_test.go pkg/ffapi/handler.go pkg/ffapi/apirequest.go pkg/ffapi/openapi3_test.go pkg/ffapi/multipart.go pkg/ffapi/swaggerui_test.go pkg/ffapi/routes.go pkg/ffapi/handler_test.go pkg/ffapi/openapi3.go pkg/ffapi/swaggerui.go pkg/i18n/errors_test.go pkg/i18n/en_base_error_messages.go pkg/i18n/messages_test.go pkg/i18n/en_base_messages.go pkg/i18n/en_base_config_descriptions.go pkg/i18n/messages.go pkg/i18n/es/es_base_config_descriptions.go pkg/i18n/errors.go
+#  Implicit rule search has not been done.
+#  Implicit/static pattern stem: `'
+#  File does not exist.
+#  File has been updated.
+#  Needs to be updated (-q is set).
+# automatic
+# @ := firefly-common
+# automatic
+# % := 
+# automatic
+# * := 
+# automatic
+# + := pkg/retry/retry_test.go pkg/retry/retry.go pkg/wsclient/wstestserver.go pkg/wsclient/wsconfig_test.go pkg/wsclient/wsclient_test.go pkg/wsclient/wsclient.go pkg/wsclient/wsconfig.go pkg/config/config.go pkg/config/config_test.go pkg/fftypes/resterror.go pkg/fftypes/uuid_test.go pkg/fftypes/jsonobject.go pkg/fftypes/sizeutils.go pkg/fftypes/config_record.go pkg/fftypes/bigint.go pkg/fftypes/bytetypes_test.go pkg/fftypes/bigint_test.go pkg/fftypes/sizeutils_test.go pkg/fftypes/jsonobjectarray.go pkg/fftypes/timeutils_test.go pkg/fftypes/idutils.go pkg/fftypes/enum_test.go pkg/fftypes/bytetypes.go pkg/fftypes/jsonobject_test.go pkg/fftypes/idutils_test.go pkg/fftypes/uuid.go pkg/fftypes/jsonany_test.go pkg/fftypes/timeutils.go pkg/fftypes/enum.go pkg/fftypes/jsonobjectarray_test.go pkg/fftypes/jsonany.go pkg/httpserver/httpserver_test.go pkg/httpserver/config.go pkg/httpserver/httpserver.go pkg/httpserver/server_cors_test.go pkg/httpserver/server_cors.go pkg/ffresty/config.go pkg/ffresty/ffresty.go pkg/ffresty/ffresty_test.go pkg/log/log.go pkg/log/log_test.go pkg/ffapi/handler.go pkg/ffapi/apirequest.go pkg/ffapi/openapi3_test.go pkg/ffapi/multipart.go pkg/ffapi/swaggerui_test.go pkg/ffapi/routes.go pkg/ffapi/handler_test.go pkg/ffapi/openapi3.go pkg/ffapi/swaggerui.go pkg/i18n/errors_test.go pkg/i18n/en_base_error_messages.go pkg/i18n/messages_test.go pkg/i18n/en_base_messages.go pkg/i18n/en_base_config_descriptions.go pkg/i18n/messages.go pkg/i18n/es/es_base_config_descriptions.go pkg/i18n/errors.go
+# automatic
+# | := 
+# automatic
+# < := pkg/retry/retry_test.go
+# automatic
+# ^ := pkg/retry/retry_test.go pkg/retry/retry.go pkg/wsclient/wstestserver.go pkg/wsclient/wsconfig_test.go pkg/wsclient/wsclient_test.go pkg/wsclient/wsclient.go pkg/wsclient/wsconfig.go pkg/config/config.go pkg/config/config_test.go pkg/fftypes/resterror.go pkg/fftypes/uuid_test.go pkg/fftypes/jsonobject.go pkg/fftypes/sizeutils.go pkg/fftypes/config_record.go pkg/fftypes/bigint.go pkg/fftypes/bytetypes_test.go pkg/fftypes/bigint_test.go pkg/fftypes/sizeutils_test.go pkg/fftypes/jsonobjectarray.go pkg/fftypes/timeutils_test.go pkg/fftypes/idutils.go pkg/fftypes/enum_test.go pkg/fftypes/bytetypes.go pkg/fftypes/jsonobject_test.go pkg/fftypes/idutils_test.go pkg/fftypes/uuid.go pkg/fftypes/jsonany_test.go pkg/fftypes/timeutils.go pkg/fftypes/enum.go pkg/fftypes/jsonobjectarray_test.go pkg/fftypes/jsonany.go pkg/httpserver/httpserver_test.go pkg/httpserver/config.go pkg/httpserver/httpserver.go pkg/httpserver/server_cors_test.go pkg/httpserver/server_cors.go pkg/ffresty/config.go pkg/ffresty/ffresty.go pkg/ffresty/ffresty_test.go pkg/log/log.go pkg/log/log_test.go pkg/ffapi/handler.go pkg/ffapi/apirequest.go pkg/ffapi/openapi3_test.go pkg/ffapi/multipart.go pkg/ffapi/swaggerui_test.go pkg/ffapi/routes.go pkg/ffapi/handler_test.go pkg/ffapi/openapi3.go pkg/ffapi/swaggerui.go pkg/i18n/errors_test.go pkg/i18n/en_base_error_messages.go pkg/i18n/messages_test.go pkg/i18n/en_base_messages.go pkg/i18n/en_base_config_descriptions.go pkg/i18n/messages.go pkg/i18n/es/es_base_config_descriptions.go pkg/i18n/errors.go
+# automatic
+# ? := pkg/retry/retry_test.go pkg/retry/retry.go pkg/wsclient/wstestserver.go pkg/wsclient/wsconfig_test.go pkg/wsclient/wsclient_test.go pkg/wsclient/wsclient.go pkg/wsclient/wsconfig.go pkg/config/config.go pkg/config/config_test.go pkg/fftypes/resterror.go pkg/fftypes/uuid_test.go pkg/fftypes/jsonobject.go pkg/fftypes/sizeutils.go pkg/fftypes/config_record.go pkg/fftypes/bigint.go pkg/fftypes/bytetypes_test.go pkg/fftypes/bigint_test.go pkg/fftypes/sizeutils_test.go pkg/fftypes/jsonobjectarray.go pkg/fftypes/timeutils_test.go pkg/fftypes/idutils.go pkg/fftypes/enum_test.go pkg/fftypes/bytetypes.go pkg/fftypes/jsonobject_test.go pkg/fftypes/idutils_test.go pkg/fftypes/uuid.go pkg/fftypes/jsonany_test.go pkg/fftypes/timeutils.go pkg/fftypes/enum.go pkg/fftypes/jsonobjectarray_test.go pkg/fftypes/jsonany.go pkg/httpserver/httpserver_test.go pkg/httpserver/config.go pkg/httpserver/httpserver.go pkg/httpserver/server_cors_test.go pkg/httpserver/server_cors.go pkg/ffresty/config.go pkg/ffresty/ffresty.go pkg/ff 
+resty/ffresty_test.go pkg/log/log.go pkg/log/log_test.go pkg/ffapi/handler.go pkg/ffapi/apirequest.go pkg/ffapi/openapi3_test.go pkg/ffapi/multipart.go pkg/ffapi/swaggerui_test.go pkg/ffapi/routes.go pkg/ffapi/handler_test.go pkg/ffapi/openapi3.go pkg/ffapi/swaggerui.go pkg/i18n/errors_test.go pkg/i18n/en_base_error_messages.go pkg/i18n/messages_test.go pkg/i18n/en_base_messages.go pkg/i18n/en_base_config_descriptions.go pkg/i18n/messages.go pkg/i18n/es/es_base_config_descriptions.go pkg/i18n/errors.go
+# variable set hash-table stats:
+# Load=8/32=25%, Rehash=0, Collisions=1/11=9%
+#  commands to execute (from `Makefile', line 36):
+	$(VGO) build ./pkg/*
+	
+
+# Not a target:
+pkg/fftypes/sizeutils_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/i18n/es/es_base_config_descriptions.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/bigint_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/resterror.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+/Users/pbroadhurst/go/bin/mockery:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 22):
+	$(VGO) install github.com/vektra/mockery/cmd/mockery@latest
+	
+
+# Not a target:
+pkg/retry/retry.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/uuid.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+mocks: mocks-pkg/httpserver-GoHTTPServer
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+
+coverage.html:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 17):
+	$(VGO) tool cover -html=coverage.txt
+	
+
+# Not a target:
+pkg/i18n/errors.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+lint: /Users/pbroadhurst/go/bin/golangci-lint
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+#  commands to execute (from `Makefile', line 20):
+	GOGC=20 $(LINT) run -v --timeout 5m
+	
+
+# Not a target:
+pkg/wsclient/wstestserver.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/config_record.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+.DELETE_ON_ERROR:
+#  Implicit rule search has not been done.
+#  Modification time never checked.
+#  File has not been updated.
+
+# Not a target:
+pkg/fftypes/jsonobjectarray_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/fftypes/bytetypes_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/httpserver/server_cors_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffresty/ffresty.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/config/config.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-01 10:44:34
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffapi/apirequest.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-06 11:57:04
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/httpserver/config.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-23 13:22:18
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/httpserver/httpserver.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/ffapi/handler_test.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-06-02 15:34:01
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# Not a target:
+pkg/log/log.go:
+#  Implicit rule search has been done.
+#  Last modified 2022-05-04 11:59:22
+#  File has been updated.
+#  Successfully updated.
+# variable set hash-table stats:
+# Load=0/32=0%, Rehash=0, Collisions=0/0=0%
+
+# files hash-table stats:
+# Load=77/1024=8%, Rehash=0, Collisions=12/161=7%
+# VPATH Search Paths
+
+# No `vpath' search paths.
+
+# No general (`VPATH' variable) search path.
+
+# # of strings in strcache: 1
+# # of strcache buffers: 1
+# strcache size: total = 4096 / max = 4096 / min = 4096 / avg = 4096
+# strcache free: total = 4087 / max = 4087 / min = 4087 / avg = 4087
+
+# Finished Make data base on Sat Jun 18 12:57:15 2022
+
+ 

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -18,7 +18,6 @@ package ffapi
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -192,7 +191,9 @@ func (sg *SwaggerGen) addInput(ctx context.Context, doc *openapi3.T, route *Rout
 	}
 	switch {
 	case route.JSONInputSchema != nil:
-		err = json.Unmarshal([]byte(route.JSONInputSchema(ctx)), &schemaRef)
+		schemaRef, err = route.JSONInputSchema(ctx, func(obj interface{}) (*openapi3.SchemaRef, error) {
+			return openapi3gen.NewSchemaRefForValue(obj, doc.Components.Schemas, openapi3gen.SchemaCustomizer(schemaCustomizer))
+		})
 		if err != nil {
 			panic(fmt.Sprintf("invalid schema: %s", err))
 		}
@@ -245,7 +246,9 @@ func (sg *SwaggerGen) addOutput(ctx context.Context, doc *openapi3.T, route *Rou
 	}
 	switch {
 	case route.JSONOutputSchema != nil:
-		err := json.Unmarshal([]byte(route.JSONOutputSchema(ctx)), &schemaRef)
+		schemaRef, err = route.JSONOutputSchema(ctx, func(obj interface{}) (*openapi3.SchemaRef, error) {
+			return openapi3gen.NewSchemaRefForValue(obj, doc.Components.Schemas, openapi3gen.SchemaCustomizer(schemaCustomizer))
+		})
 		if err != nil {
 			panic(fmt.Sprintf("invalid schema: %s", err))
 		}

--- a/pkg/ffapi/routes.go
+++ b/pkg/ffapi/routes.go
@@ -19,9 +19,14 @@ package ffapi
 import (
 	"context"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 )
+
+// SchemaGenerator is passed into the JSONInputSchema advanced customization function, to give
+// access to tools like object schema generation, for an anyOf schema for example
+type SchemaGenerator func(o interface{}) (*openapi3.SchemaRef, error)
 
 // Route defines each API operation on the REST API of Firefly
 // Having a standard pluggable layer here on top of Gorilla allows us to autmoatically
@@ -49,9 +54,9 @@ type Route struct {
 	// JSONInputMask are fields that aren't available for users to supply on input
 	JSONInputMask []string
 	// JSONInputSchema is a custom schema definition, for the case where the auto-gen + mask isn't good enough
-	JSONInputSchema func(ctx context.Context) string
+	JSONInputSchema func(ctx context.Context, schemaGen SchemaGenerator) (*openapi3.SchemaRef, error)
 	// JSONOutputSchema is a custom schema definition, for the case where the auto-gen + mask isn't good enough
-	JSONOutputSchema func(ctx context.Context) string
+	JSONOutputSchema func(ctx context.Context, schemaGen SchemaGenerator) (*openapi3.SchemaRef, error)
 	// JSONOutputValue is a function that returns a pointer to a structure to take JSON output
 	JSONOutputValue func() interface{}
 	// JSONOutputCodes is the success response code


### PR DESCRIPTION
Need a way to be able to define an `anyOf` schema, which fits nicely with the advanced `ffapi` option for returning a Schema directly. This is for the RPC-style APIs of connectors, where they take a bunch of different payloads that all have some common headers.

However, currently this  custom function can't access all the `struct` schema generation features, so you have to go fully manual - which seems wrong. So I've updated the interface.

I believe all uses of this customization in FireFly core were removed perviously, because of this kind of restriction meaning they are were too static. We took the hit on losing the extra info on the API description, in favor of ensuring it stayed up to date. So this PR should also open the door to re-instating that going forwards.