### PR TITLE
Allow number and boolean as JSON schema options

### DIFF
--- a/pkg/fftypes/ffi_param_validator.go
+++ b/pkg/fftypes/ffi_param_validator.go
@@ -30,13 +30,15 @@ func (v *BaseFFIParamValidator) GetMetaSchema() *jsonschema.Schema {
 	return jsonschema.MustCompileString("ffi.json", `{
 		"$ref": "#/$defs/ffiParam",
 		"$defs": {
-			"integerTypeOptions": {
+			"nonStringTypeOptions": {
 				"type": "object",
 				"properties": {
 					"type": {
 						"type": "string",
 						"enum": [
 							"integer",
+							"number",
+							"boolean",
 							"string"
 						]
 					}
@@ -53,6 +55,7 @@ func (v *BaseFFIParamValidator) GetMetaSchema() *jsonschema.Schema {
 								"enum": [
 									"boolean",
 									"integer",
+									"number",
 									"string",
 									"array",
 									"object"
@@ -69,7 +72,7 @@ func (v *BaseFFIParamValidator) GetMetaSchema() *jsonschema.Schema {
 							"oneOf": {
 								"type": "array",
 								"items": {
-									"$ref": "#/$defs/integerTypeOptions"
+									"$ref": "#/$defs/nonStringTypeOptions"
 								}
 							}
 						},


### PR DESCRIPTION
See https://github.com/hyperledger/firefly-signer/pull/11

- Allows `number` for non-integer types (`fixed`/`ufixed`) that can be specified as non-string
- Update `boolean` support to include `true`/`false` strings as an option (all elementary types allow string basically)