### PR TITLE
Allow numbers and booleans to be expressed as strings

### DIFF
--- a/pkg/fftypes/ffi_param_validator.go
+++ b/pkg/fftypes/ffi_param_validator.go
@@ -42,6 +42,30 @@ func (v *BaseFFIParamValidator) GetMetaSchema() *jsonschema.Schema {
 					}
 				}
 			},
+			"numberTypeOptions": {
+				"type": "object",
+				"properties": {
+					"type": {
+						"type": "string",
+						"enum": [
+							"number",
+							"string"
+						]
+					}
+				}
+			},
+			"booleanTypeOptions": {
+				"type": "object",
+				"properties": {
+					"type": {
+						"type": "string",
+						"enum": [
+							"boolean",
+							"string"
+						]
+					}
+				}
+			},
 			"ffiParam": {
 				"oneOf": [
 					{
@@ -68,9 +92,23 @@ func (v *BaseFFIParamValidator) GetMetaSchema() *jsonschema.Schema {
 						"properties": {
 							"oneOf": {
 								"type": "array",
-								"items": {
-									"$ref": "#/$defs/integerTypeOptions"
-								}
+								"oneOf": [
+									{
+										"items": {
+											"$ref": "#/$defs/integerTypeOptions"
+										}
+									},
+									{
+										"items": {
+											"$ref": "#/$defs/numberTypeOptions"
+										}
+									},
+									{
+										"items": {
+											"$ref": "#/$defs/booleanTypeOptions"
+										}
+									}
+								]
 							}
 						},
 						"required": [


### PR DESCRIPTION
A slight improvement/replacement for https://github.com/hyperledger/firefly-common/pull/21.

See https://github.com/hyperledger/firefly-signer/pull/11

Allows number for non-integer types (fixed/ufixed) that can be specified as non-string
Update boolean support to include true/false strings as an option (all elementary types allow string basically)

These changes also enforce that a schema cannot allow a `boolean` and a `number` for the same field, as an example