### PR TITLE
Add number to list of allowed JSON input types

### DIFF
--- a/pkg/fftypes/ffi_param_validator.go
+++ b/pkg/fftypes/ffi_param_validator.go
@@ -77,6 +77,7 @@ func (v *BaseFFIParamValidator) GetMetaSchema() *jsonschema.Schema {
 								"enum": [
 									"boolean",
 									"integer",
+									"number",
 									"string",
 									"array",
 									"object"


### PR DESCRIPTION
I missed this one in the pervious merge when porting over @peterbroadhurst's changes 🙁 