### PR TITLE
remove namespace check from FFI

### DIFF
--- a/pkg/fftypes/ffi.go
+++ b/pkg/fftypes/ffi.go
@@ -92,9 +92,6 @@ type FFIGenerationRequest struct {
 }
 
 func (f *FFI) Validate(ctx context.Context, existing bool) (err error) {
-	if err = ValidateFFNameField(ctx, f.Namespace, "namespace"); err != nil {
-		return err
-	}
 	if err = ValidateFFNameField(ctx, f.Name, "name"); err != nil {
 		return err
 	}

--- a/pkg/fftypes/ffi_test.go
+++ b/pkg/fftypes/ffi_test.go
@@ -87,16 +87,6 @@ func TestValidateFFIBadName(t *testing.T) {
 	assert.Regexp(t, "FF00140", err)
 }
 
-func TestValidateFFIBadNamespace(t *testing.T) {
-	ffi := &FFI{
-		Name:      "math",
-		Namespace: "",
-		Version:   "v1.0.0",
-	}
-	err := ffi.Validate(context.Background(), true)
-	assert.Regexp(t, "FF00140", err)
-}
-
 func TestFFIParamsScan(t *testing.T) {
 	params := &FFIParams{}
 	err := params.Scan([]byte(`[{"name": "x", "type": "integer", "internalType": "uint256"}]`))


### PR DESCRIPTION
Now that https://github.com/hyperledger/firefly/pull/895 has been merged, definitions are no longer transmitted with a `namespace`. This PR removes the namespace validation FFI's. 