### PR TITLE
Utility for serializing structs into a JSON Map (or fftypes.JSONObject)

### DIFF
--- a/pkg/jsonmap/jsonmap.go
+++ b/pkg/jsonmap/jsonmap.go
@@ -1,0 +1,74 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonmap
+
+import (
+	"reflect"
+	"strings"
+)
+
+// AddJSONFieldsToMap is a helper for marshalling struct fields down into a map
+//
+// Note: Does not currently respect the `omitempty` JSON flag semantics
+func AddJSONFieldsToMap(val reflect.Value, data map[string]interface{}) {
+	varType := val.Type()
+	if varType.Kind() == reflect.Ptr {
+		AddJSONFieldsToMap(val.Elem(), data)
+		return
+	}
+	for i := 0; i < varType.NumField(); i++ {
+		f := val.Field(i)
+		fType := varType.Field(i)
+		if fType.Anonymous {
+			AddJSONFieldsToMap(f, data)
+			continue
+		}
+		if !f.CanInterface() {
+			continue
+		}
+		tag, ok := varType.Field(i).Tag.Lookup(`json`)
+		var fieldName string
+		if ok && len(tag) > 0 {
+			if tag == "-" || strings.Contains(tag, ",omitempty") && isEmptyValue(f) {
+				continue
+			}
+			fieldName = tag
+		} else {
+			fieldName = fType.Name
+		}
+		data[fieldName] = f.Interface()
+	}
+}
+
+// had to copy these rules over from json as not exposed
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}

--- a/pkg/jsonmap/jsonmap.go
+++ b/pkg/jsonmap/jsonmap.go
@@ -28,8 +28,6 @@ func StructToJSONMap(i interface{}) map[string]interface{} {
 }
 
 // AddJSONFieldsToMap is a helper for marshalling struct fields down into a map
-//
-// Note: Does not currently respect the `omitempty` JSON flag semantics
 func AddJSONFieldsToMap(val reflect.Value, data map[string]interface{}) {
 	varType := val.Type()
 	if varType.Kind() == reflect.Ptr {

--- a/pkg/jsonmap/jsonmap.go
+++ b/pkg/jsonmap/jsonmap.go
@@ -21,6 +21,12 @@ import (
 	"strings"
 )
 
+func StructToJSONMap(i interface{}) map[string]interface{} {
+	m := make(map[string]interface{})
+	AddJSONFieldsToMap(reflect.ValueOf(i), m)
+	return m
+}
+
 // AddJSONFieldsToMap is a helper for marshalling struct fields down into a map
 //
 // Note: Does not currently respect the `omitempty` JSON flag semantics

--- a/pkg/jsonmap/jsonmap_test.go
+++ b/pkg/jsonmap/jsonmap_test.go
@@ -57,8 +57,7 @@ func TestAddJSONFieldsToMap(t *testing.T) {
 		EmptySeven:    []string{},
 	}
 
-	m := make(map[string]interface{})
-	AddJSONFieldsToMap(reflect.ValueOf(t1), m)
+	m := StructToJSONMap(t1)
 	b, err := json.Marshal(m)
 	assert.NoError(t, err)
 	assert.Equal(t, `{"DefaultName":"def111","f1":"val1","f2":2222,"f3":"val3"}`, string(b))

--- a/pkg/jsonmap/jsonmap_test.go
+++ b/pkg/jsonmap/jsonmap_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonmap
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddJSONFieldsToMap(t *testing.T) {
+
+	type testType1 struct {
+		Field1 string `json:"f1"`
+		Field2 int64  `json:"f2"`
+	}
+
+	type testType2 struct {
+		testType1
+		Field3        string `json:"f3"`
+		IgnoreMe      string `json:"-"`
+		DefaultName   string
+		internalField string
+		EmptyOne      *string  `json:"e1,omitempty"`
+		EmptyTwo      string   `json:"e2,omitempty"`
+		EmptyThree    int64    `json:"e3,omitempty"`
+		EmptyFour     uint64   `json:"e4,omitempty"`
+		EmptyFive     float64  `json:"e5,omitempty"`
+		EmptySix      bool     `json:"e6,omitempty"`
+		EmptySeven    []string `json:"e7,omitempty"`
+	}
+
+	t1 := &testType2{
+		testType1: testType1{
+			Field1: "val1",
+			Field2: 2222,
+		},
+		Field3:        "val3",
+		DefaultName:   "def111",
+		internalField: "internal",
+		EmptySeven:    []string{},
+	}
+
+	m := make(map[string]interface{})
+	AddJSONFieldsToMap(reflect.ValueOf(t1), m)
+	b, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"DefaultName":"def111","f1":"val1","f2":2222,"f3":"val3"}`, string(b))
+
+}
+
+func TestUnknownEmpty(t *testing.T) {
+	assert.False(t, isEmptyValue(reflect.ValueOf(make(chan struct{}))))
+}


### PR DESCRIPTION
This utility lets you use the standard JSON serialization policy for fields in go structs, to write fields into a map.

This has two uses in FireFly to avoid horrible JSON marshal/unmarshal loops:

1. Combining multiple Go structures from plugins into an extensible JSON body - required in FFTM here https://github.com/hyperledger/firefly-transaction-manager/pull/14
2. Converting from Go structs to an `fftypes.JSONObject`