### PR TITLE
Allow maximum request timeout to be larger than write timeout (avoid EOF)

### DIFF
--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -51,6 +51,7 @@ type httpServer struct {
 	l               net.Listener
 	conf            config.Section
 	corsConf        config.Section
+	options         ServerOptions
 	onClose         chan error
 	tlsEnabled      bool
 	tlsCertFile     string
@@ -58,7 +59,13 @@ type httpServer struct {
 	shutdownTimeout time.Duration
 }
 
-func NewHTTPServer(ctx context.Context, name string, r *mux.Router, onClose chan error, conf config.Section, corsConf config.Section) (is HTTPServer, err error) {
+// ServerOptions are config parameters that are not set from the config, but rather the context
+// in which the HTTP server is being used
+type ServerOptions struct {
+	MaximumRequestTimeout time.Duration
+}
+
+func NewHTTPServer(ctx context.Context, name string, r *mux.Router, onClose chan error, conf config.Section, corsConf config.Section, opts ...*ServerOptions) (is HTTPServer, err error) {
 	hs := &httpServer{
 		name:            name,
 		onClose:         onClose,
@@ -68,6 +75,9 @@ func NewHTTPServer(ctx context.Context, name string, r *mux.Router, onClose chan
 		tlsCertFile:     conf.GetString(HTTPConfTLSCertFile),
 		tlsKeyFile:      conf.GetString(HTTPConfTLSKeyFile),
 		shutdownTimeout: conf.GetDuration(HTTPConfShutdownTimeout),
+	}
+	for _, o := range opts {
+		hs.options = *o
 	}
 	hs.l, err = hs.createListener(ctx)
 	if err == nil {
@@ -126,11 +136,25 @@ func (hs *httpServer) createServer(ctx context.Context, r *mux.Router) (srv *htt
 		return nil, err
 	}
 	handler = wrapCorsIfEnabled(ctx, hs.corsConf, handler)
+
+	// Where a maximum request timeout is set, it does not make sense for either the
+	// read timeout (time to read full body), or the write timeout (time to write the
+	// response after processing the request) to be less than that
+	readTimeout := hs.conf.GetDuration(HTTPConfReadTimeout)
+	if readTimeout < hs.options.MaximumRequestTimeout {
+		readTimeout = hs.options.MaximumRequestTimeout + 1*time.Second
+	}
+	writeTimeout := hs.conf.GetDuration(HTTPConfWriteTimeout)
+	if writeTimeout < hs.options.MaximumRequestTimeout {
+		writeTimeout = hs.options.MaximumRequestTimeout + 1*time.Second
+	}
+
+	log.L(ctx).Debugf("HTTP Server Timeouts (%s): read=%s write=%s request=%s", hs.l.Addr(), readTimeout, writeTimeout, hs.options.MaximumRequestTimeout)
 	srv = &http.Server{
 		Handler:           handler,
-		WriteTimeout:      hs.conf.GetDuration(HTTPConfWriteTimeout),
-		ReadTimeout:       hs.conf.GetDuration(HTTPConfReadTimeout),
-		ReadHeaderTimeout: hs.conf.GetDuration(HTTPConfReadTimeout),
+		WriteTimeout:      writeTimeout,
+		ReadTimeout:       readTimeout,
+		ReadHeaderTimeout: hs.conf.GetDuration(HTTPConfReadTimeout), // safe for this to always be the read timeout - should be short
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 			ClientAuth: clientAuth,

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -70,7 +70,7 @@ func TestServeFail(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestShutdownOk(t *testing.T) {
+func TestShutdownOkCustomOpts(t *testing.T) {
 	config.RootConfigReset()
 	cp := config.RootSection("ut")
 	InitHTTPConfig(cp, 0)
@@ -78,9 +78,12 @@ func TestShutdownOk(t *testing.T) {
 	InitCORSConfig(cc)
 	errChan := make(chan error)
 	ctx, cancel := context.WithCancel(context.Background())
-	l, err := NewHTTPServer(ctx, "ut", mux.NewRouter(), errChan, cp, cc)
+	l, err := NewHTTPServer(ctx, "ut", mux.NewRouter(), errChan, cp, cc, &ServerOptions{
+		MaximumRequestTimeout: 1 * time.Hour,
+	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, l.Addr().String())
+	assert.Equal(t, 1*time.Hour, l.(*httpServer).options.MaximumRequestTimeout)
 	cancel()
 }
 


### PR DESCRIPTION
The `WriteTimeout` in Go is actually the time all the way from the reading of the headers, until the data has been fully written in the response.

In an example E2E test with confirmations, so that synchronous calls take longer than 15s to complete, we see:

```
Websocket 127.0.0.1:5000 event: default/token_pool_confirmed/339d3f53-37de-4baa-bd46-e4277aeb315e -> c4a76e57-d586-4cbf-9581-b0deb5352ec4 (tx=%!s(*core.Transaction=<nil>))
    restclient.go:552: 
                Error Trace:    /Users/pbroadhurst/dev/firefly/firefly/test/e2e/runners/restclient.go:552
                                                        /Users/pbroadhurst/dev/firefly/firefly/test/e2e/runners/tokens.go:231
                Error:          Received unexpected error:
                                Post "http://127.0.0.1:5000/api/v1/namespaces/default/tokens/pools?confirm=true": EOF
                Test:           TestEthereumMultipartyE2ESuite/TestE2ENonFungibleTokensSync
```

This PR allows the constructor of the HTTP Server to include a MaximumRequestTimeout, which forces the read timeout and the write timeout (not the read header timeout) to be larger than this value.

It adds 1 second buffer, so that a nice error message can be returned in the case of a context based request timeout.