### PR TITLE
adding IsSet function for default value checking

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,6 +111,8 @@ type Section interface {
 	GetObject(key string) fftypes.JSONObject
 	GetObjectArray(key string) fftypes.JSONObjectArray
 	Get(key string) interface{}
+
+	IsSet(key string) bool
 }
 
 // ArraySection represents an array of options at a particular layer in the config.
@@ -582,6 +584,18 @@ func (c *configSection) Resolve(key string) string {
 	defer keysMutex.Unlock()
 
 	return c.prefixKey(key)
+}
+
+func IsSet(key RootKey) bool {
+	return root.IsSet(string(key))
+}
+
+// IsSet return whether a key has non-default value set
+func (c *configSection) IsSet(key string) bool {
+	keysMutex.Lock()
+	defer keysMutex.Unlock()
+
+	return viper.IsSet(key)
 }
 
 // SetupLogging initializes logging

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -82,6 +82,14 @@ func TestDefaults(t *testing.T) {
 	assert.Equal(t, int64(1024*1024), GetByteSize(key9))
 }
 
+func TestValueSet(t *testing.T) {
+	RootConfigReset()
+	// keys with default values are not set
+	assert.False(t, IsSet("key1"))
+	Set("key1", "updatedvalue")
+	assert.True(t, IsSet("key1"))
+}
+
 func TestSpecificConfigFileOk(t *testing.T) {
 	RootConfigReset()
 	err := ReadConfig("common", configDir+"/firefly.common.yaml")


### PR DESCRIPTION
For configuration migration. Exposing IsSet function so that we can check whether a key is manually set by the users.

Signed-off-by: Chengxuan Xing <chengxuan.xing@kaleido.io>