### PR TITLE
Change to X-FireFly-Request-ID header name

### DIFF
--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,7 +34,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/log"
 )
 
-const FFRequestIDHeader = "X-FireFlyRequestID"
+const FFRequestIDHeader = "X-FireFly-Request-ID"
 
 type (
 	CtxHeadersKey     struct{}


### PR DESCRIPTION
Signed-off-by: Nicko Guyer <nicko.guyer@kaleido.io>