### PR TITLE
Add ability to register custom message catalogs

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,7 +19,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -245,7 +244,7 @@ func TestSetupLoggingToFile(t *testing.T) {
 	RootConfigReset()
 	SetupLogging(context.Background())
 
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	assert.NoError(t, err)
 	assert.Regexp(t, "Log level", string(b))
 }

--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"reflect"
@@ -74,7 +73,7 @@ func (hs *HandlerFactory) getFilePart(req *http.Request) (*multipartState, error
 			return nil, i18n.WrapError(ctx, err, i18n.MsgMultiPartFormReadError)
 		}
 		if part.FileName() == "" {
-			value, _ := ioutil.ReadAll(part)
+			value, _ := io.ReadAll(part)
 			formParams[part.FormName()] = string(value)
 		} else {
 			l.Debugf("Processing multi-part upload. Field='%s' Filename='%s'", part.FormName(), part.FileName())

--- a/pkg/ffapi/handler_test.go
+++ b/pkg/ffapi/handler_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -303,10 +303,10 @@ func TestMultipartBinary(t *testing.T) {
 		JSONOutputCodes: []int{http.StatusCreated},
 		FormUploadHandler: func(r *APIRequest) (output interface{}, err error) {
 			assert.Equal(t, "testing", r.FP["param1"])
-			d, err := ioutil.ReadAll(r.Part.Data)
+			d, err := io.ReadAll(r.Part.Data)
 			assert.NoError(t, err)
 			assert.Equal(t, "some data", string(d))
-			return ioutil.NopCloser(strings.NewReader(`{"ok":true}`)), nil
+			return io.NopCloser(strings.NewReader(`{"ok":true}`)), nil
 		},
 	}})
 	defer done()
@@ -327,7 +327,7 @@ func TestMultipartBinary(t *testing.T) {
 	res, err := http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 201, res.StatusCode)
-	bodyBytes, err := ioutil.ReadAll(res.Body)
+	bodyBytes, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"ok":true}`, string(bodyBytes))
 }

--- a/pkg/ffresty/ffresty.go
+++ b/pkg/ffresty/ffresty.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -192,7 +192,7 @@ func WrapRestErr(ctx context.Context, res *resty.Response, err error, key i18n.E
 	if res != nil {
 		if res.RawBody() != nil {
 			defer func() { _ = res.RawBody().Close() }()
-			if r, err := ioutil.ReadAll(res.RawBody()); err == nil {
+			if r, err := io.ReadAll(res.RawBody()); err == nil {
 				respData = string(r)
 			}
 		}

--- a/pkg/fftypes/auth.go
+++ b/pkg/fftypes/auth.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -13,6 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package fftypes
 
 import (

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -21,9 +21,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -114,7 +114,7 @@ func (hs *httpServer) createServer(ctx context.Context, r *mux.Router) (srv *htt
 	if caFile != "" {
 		rootCAs = x509.NewCertPool()
 		var caBytes []byte
-		caBytes, err = ioutil.ReadFile(caFile)
+		caBytes, err = os.ReadFile(caFile)
 		if err == nil {
 			ok := rootCAs.AppendCertsFromPEM(caBytes)
 			if !ok {

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -141,7 +140,7 @@ func TestTLSServerSelfSignedWithClientAuth(t *testing.T) {
 	privatekey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publickey := &privatekey.PublicKey
 	var privateKeyBytes []byte = x509.MarshalPKCS1PrivateKey(privatekey)
-	privateKeyFile, _ := ioutil.TempFile("", "key.pem")
+	privateKeyFile, _ := os.CreateTemp("", "key.pem")
 	defer os.Remove(privateKeyFile.Name())
 	privateKeyBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privateKeyBytes}
 	pem.Encode(privateKeyFile, privateKeyBlock)
@@ -159,7 +158,7 @@ func TestTLSServerSelfSignedWithClientAuth(t *testing.T) {
 	}
 	derBytes, err := x509.CreateCertificate(rand.Reader, x509Template, x509Template, publickey, privatekey)
 	assert.NoError(t, err)
-	publicKeyFile, _ := ioutil.TempFile("", "cert.pem")
+	publicKeyFile, _ := os.CreateTemp("", "cert.pem")
 	defer os.Remove(publicKeyFile.Name())
 	pem.Encode(publicKeyFile, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 
@@ -189,7 +188,7 @@ func TestTLSServerSelfSignedWithClientAuth(t *testing.T) {
 
 	// Attempt a request, with a client certificate
 	rootCAs := x509.NewCertPool()
-	caPEM, _ := ioutil.ReadFile(publicKeyFile.Name())
+	caPEM, _ := os.ReadFile(publicKeyFile.Name())
 	ok := rootCAs.AppendCertsFromPEM(caPEM)
 	assert.True(t, ok)
 	c := http.Client{

--- a/pkg/i18n/messages.go
+++ b/pkg/i18n/messages.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -19,6 +19,7 @@ package i18n
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"golang.org/x/text/language"
@@ -68,6 +69,28 @@ var fieldTypes = map[string]string{}
 var msgIDUniq = map[string]bool{}
 
 var fallbackLangPrinter = message.NewPrinter(language.AmericanEnglish)
+
+var prefixValidator = regexp.MustCompile(`[A-Z][A-Z]\d\d`)
+
+// RegisterPrefix allows components to register a message prefix that is not known to the core
+// Hyperledger FireFly codebase. The firefly-common repo does not provide the clash-protection
+// for these prefixes - so if you're writing a new component within the FF OSS community
+// then you should instead submit a PR to update the registeredPrefixes constant.
+//
+// If you're writing a proprietary extension, or just using the Microservice framework for your
+// own purposes, then you can register your own prefix with this function dynamically.
+//
+// It must conform to being two upper case characters, then two numbers.
+// You cannot use the `FF` prefix characters, as they are reserved for FireFly components
+func RegisterPrefix(prefix, description string) {
+	if !prefixValidator.MatchString(prefix) || strings.HasPrefix(prefix, "FF") {
+		panic("invalid prefix")
+	}
+	if _, ok := registeredPrefixes[prefix]; ok {
+		panic("duplicate prefix")
+	}
+	registeredPrefixes[prefix] = description
+}
 
 // FFE is the translation helper to register an error message
 func FFE(language language.Tag, key, translation string, statusHint ...int) ErrorMessageKey {

--- a/pkg/i18n/messages.go
+++ b/pkg/i18n/messages.go
@@ -84,10 +84,10 @@ var prefixValidator = regexp.MustCompile(`[A-Z][A-Z]\d\d`)
 // You cannot use the `FF` prefix characters, as they are reserved for FireFly components
 func RegisterPrefix(prefix, description string) {
 	if !prefixValidator.MatchString(prefix) || strings.HasPrefix(prefix, "FF") {
-		panic("invalid prefix")
+		panic(fmt.Sprintf("invalid prefix %q", prefix))
 	}
 	if _, ok := registeredPrefixes[prefix]; ok {
-		panic("duplicate prefix")
+		panic(fmt.Sprintf("duplicate prefix %q", prefix))
 	}
 	registeredPrefixes[prefix] = description
 }

--- a/pkg/i18n/messages_test.go
+++ b/pkg/i18n/messages_test.go
@@ -127,3 +127,29 @@ func TestDuplicateConfigKey(t *testing.T) {
 		FFC(language.AmericanEnglish, "config.test.2", "test2 dupe", "dupe type")
 	})
 }
+
+func TestRegisterPrefixOK(t *testing.T) {
+	RegisterPrefix("AB12", "my microservice")
+	msgMyMessage := ffe("AB1200000", "Something went pop")
+	err := NewError(context.Background(), msgMyMessage)
+	assert.Regexp(t, "AB1200000", err)
+}
+
+func TestRegisterPrefixInvalid(t *testing.T) {
+	assert.Panics(t, func() {
+		RegisterPrefix("wrong", "my microservice")
+	})
+}
+
+func TestRegisterPrefixFF(t *testing.T) {
+	assert.Panics(t, func() {
+		RegisterPrefix("wrong", "FF01")
+	})
+}
+
+func TestRegisterPrefixDuplicate(t *testing.T) {
+	assert.Panics(t, func() {
+		RegisterPrefix("AB12", "my microservice")
+		RegisterPrefix("AB12", "my microservice")
+	})
+}

--- a/pkg/wsclient/wsclient.go
+++ b/pkg/wsclient/wsclient.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -224,7 +224,7 @@ func (w *wsClient) connect(initial bool) error {
 			var b []byte
 			var status = -1
 			if res != nil {
-				b, _ = ioutil.ReadAll(res.Body)
+				b, _ = io.ReadAll(res.Body)
 				res.Body.Close()
 				status = res.StatusCode
 			}


### PR DESCRIPTION
Currently we have a source-code controlled list of message catalogs for core FireFly components, to avoid clashes.

However, this precludes use of the utility functions outside of core FireFly codebases - such as in custom plugins under development. It's a useful library, and this restriction doesn't seem to make sense. Even worse we might end up in a position where code uses the wrong message catalog to define messages for convenience.