### PR TITLE
Add getter for DB provider features struct field

### DIFF
--- a/pkg/dbsql/database.go
+++ b/pkg/dbsql/database.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -108,6 +108,10 @@ func (s *Database) Init(ctx context.Context, provider Provider, config config.Se
 
 func (s *Database) ConnLimit() int {
 	return s.connLimit
+}
+
+func (s *Database) Features() SQLFeatures {
+	return s.features
 }
 
 func (s *Database) SequenceColumn() string {

--- a/pkg/dbsql/database_test.go
+++ b/pkg/dbsql/database_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -62,6 +62,19 @@ func TestInitDatabaseConnsAndSeqCol(t *testing.T) {
 
 	assert.Equal(t, 10, s.ConnLimit())
 	assert.Equal(t, "seq", s.SequenceColumn())
+}
+
+func TestInitDatabaseFeatures(t *testing.T) {
+	s := &Database{}
+	tp := newMockProvider()
+	s.InitConfig(tp, tp.config)
+	err := s.Init(context.Background(), tp, tp.config)
+	assert.NoError(t, err)
+	assert.NotNil(t, s.DB())
+
+	assert.NotNil(t, s.Features())
+	assert.Equal(t, true, s.Features().UseILIKE)
+	assert.Equal(t, false, s.Features().MultiRowInsert)
 }
 
 func TestInitDatabaseOpenFailed(t *testing.T) {


### PR DESCRIPTION
Looking into issue https://github.com/hyperledger/firefly/issues/1196 (now spun out into https://github.com/hyperledger/firefly/issues/1199) it appears that the `features` struct field is no longer visible to users of the package. Adding a getter in a similar way to the existing `ConnLimit()` getter makes the field accessible to read.