### PR TITLE
move file watcher to a common package

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
+	"github.com/hyperledger/firefly-common/pkg/fswatcher"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/sirupsen/logrus"
@@ -176,6 +177,18 @@ func ReadConfig(cfgSuffix, cfgFile string) error {
 		viper.SetConfigFile(cfgFile)
 	}
 	return viper.ReadInConfig()
+}
+
+// Listens for changes to the configuration file configured in Viper.
+func WatchConfig(ctx context.Context, onChange, onClose func()) error {
+
+	// Note that while viper.WatchConfig() exists, it doesn't handle various
+	// types of config change. Specifically it doesn't handle the case where the
+	// removed event comes from the filesystem, before the create/update event(s).
+	// The listener just ends in that case, and stops notifying of events :shrug
+
+	fullConfigFilePath := viper.ConfigFileUsed()
+	return fswatcher.Watch(ctx, fullConfigFilePath, onChange, onClose)
 }
 
 func MergeConfig(configRecords []*fftypes.ConfigRecord) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -27,6 +27,7 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/text/language"
@@ -365,5 +366,48 @@ func TestGenerateConfigMarkdownPanic(t *testing.T) {
 			string(key1),
 		})
 	})
+
+}
+
+func TestConfigWatchE2E(t *testing.T) {
+
+	logrus.SetLevel(logrus.DebugLevel)
+	tmpDir := t.TempDir()
+
+	viper.SetConfigType("yaml")
+	viper.SetConfigFile(fmt.Sprintf("%s/test.yaml", tmpDir))
+
+	// Start listener on empty dir
+	fsListenerDone := make(chan struct{})
+	fsListenerFired := make(chan bool)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	err := WatchConfig(ctx, func() {
+		err := viper.ReadInConfig()
+		assert.NoError(t, err)
+		fsListenerFired <- true
+	}, func() {
+		close(fsListenerDone)
+	})
+	assert.NoError(t, err)
+
+	// Create the file
+	os.WriteFile(fmt.Sprintf("%s/test.yaml", tmpDir), []byte(`{"ut_conf": "one"}`), 0664)
+	<-fsListenerFired
+	assert.Equal(t, "one", viper.Get("ut_conf"))
+
+	// Delete and rename in another file
+	os.Remove(fmt.Sprintf("%s/test.yaml", tmpDir))
+	os.WriteFile(fmt.Sprintf("%s/another.yaml", tmpDir), []byte(`{"ut_conf": "two"}`), 0664)
+	os.Rename(fmt.Sprintf("%s/another.yaml", tmpDir), fmt.Sprintf("%s/test.yaml", tmpDir))
+	<-fsListenerFired
+	assert.Equal(t, "two", viper.Get("ut_conf"))
+
+	defer func() {
+		cancelCtx()
+		if a := recover(); a != nil {
+			panic(a)
+		}
+		<-fsListenerDone
+	}()
 
 }

--- a/pkg/fswatcher/fswatcher_test.go
+++ b/pkg/fswatcher/fswatcher_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package fswatcher
 
 import (
 	"context"
@@ -33,14 +33,16 @@ func TestFileListenerE2E(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	tmpDir := t.TempDir()
 
+	filePath := fmt.Sprintf(fmt.Sprintf("%s/test.yaml", tmpDir))
+
 	viper.SetConfigType("yaml")
-	viper.SetConfigFile(fmt.Sprintf("%s/test.yaml", tmpDir))
+	viper.SetConfigFile(filePath)
 
 	// Start listener on empty dir
 	fsListenerDone := make(chan struct{})
 	fsListenerFired := make(chan bool)
 	ctx, cancelCtx := context.WithCancel(context.Background())
-	err := WatchConfig(ctx, func() {
+	err := Watch(ctx, filePath, func() {
 		err := viper.ReadInConfig()
 		assert.NoError(t, err)
 		fsListenerFired <- true
@@ -77,10 +79,12 @@ func TestFileListenerFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	os.RemoveAll(tmpDir)
 
-	viper.SetConfigType("yaml")
-	viper.SetConfigFile(fmt.Sprintf("%s/test.yaml", tmpDir))
+	filepath := fmt.Sprintf("%s/test.yaml", tmpDir)
 
-	err := WatchConfig(context.Background(), nil, nil)
+	viper.SetConfigType("yaml")
+	viper.SetConfigFile(filepath)
+
+	err := Watch(context.Background(), filepath, nil, nil)
 	assert.Regexp(t, "FF00194", err)
 }
 


### PR DESCRIPTION
Moves the file watcher logic to a new package, `fswatcher`, for potential use outside of viper config watching