### PR TITLE
improvements for metrics 

### DIFF
--- a/pkg/metric/metric_test.go
+++ b/pkg/metric/metric_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestMetricsRegistry(t *testing.T) {
-	mr := NewPrometheusMetricsRegistry()
+	mr := NewPrometheusMetricsRegistry("test")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	_, err := mr.HTTPHandler(ctx, promhttp.HandlerOpts{})
@@ -40,7 +40,7 @@ func TestMetricsRegistry(t *testing.T) {
 }
 
 func TestMetricsManager(t *testing.T) {
-	mr := NewPrometheusMetricsRegistry()
+	mr := NewPrometheusMetricsRegistry("test")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	mm, err := mr.NewMetricsManagerForSubsystem(ctx, "tm")
@@ -67,7 +67,7 @@ func TestMetricsManager(t *testing.T) {
 }
 
 func TestMetricsManagerWithDefaultLabels(t *testing.T) {
-	mr := NewPrometheusMetricsRegistry()
+	mr := NewPrometheusMetricsRegistry("test")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	mm, err := mr.NewMetricsManagerForSubsystem(ctx, "tm")
@@ -105,7 +105,7 @@ func TestMetricsManagerWithDefaultLabels(t *testing.T) {
 }
 
 func TestMetricsManagerErrors(t *testing.T) {
-	mr := NewPrometheusMetricsRegistry()
+	mr := NewPrometheusMetricsRegistry("test")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	mm, err := mr.NewMetricsManagerForSubsystem(ctx, "tm")
@@ -122,7 +122,7 @@ func TestMetricsManagerErrors(t *testing.T) {
 	assert.Regexp(t, "FF00195", err)
 
 	// swallow init errors
-	mm.NewCounterMetric(ctx, "txInvalidName", "Invalid name", false)
+	mm.NewCounterMetric(ctx, "tx Invalid Name", "Invalid name", false)
 	mm.NewGaugeMetric(ctx, "tx_duplicate", "Duplicate registration", false)
 	mm.NewGaugeMetric(ctx, "tx_duplicate", "Duplicate registration", false)
 	mm.NewGaugeMetric(ctx, "tx_no_help_text", "", false)
@@ -141,10 +141,10 @@ func TestMetricsManagerErrors(t *testing.T) {
 }
 
 func TestHTTPMetricsInstrumentations(t *testing.T) {
-	mr := NewPrometheusMetricsRegistry()
+	mr := NewPrometheusMetricsRegistry("test")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err := mr.NewHTTPMetricsInstrumentationsForSubsystem(ctx, "api_server", true, []float64{}, map[string]string{})
+	err := mr.NewHTTPMetricsInstrumentationsForSubsystem(ctx, "api_server", true, []float64{}, nil)
 	assert.NoError(t, err)
 	err = mr.NewHTTPMetricsInstrumentationsForSubsystem(ctx, "api_server", true, []float64{}, map[string]string{})
 	assert.Error(t, err)


### PR DESCRIPTION
Here is the list of improvements:
- Added go and cpu metrics as default
- added more documentation on how the terms used in function names are used in a real metrics string
- added a way to add a component label for all metrics so that we can separate the same metrics (e.g. HTTP requests) of different components
- allowed more chars to be used in the name string