### PR TITLE
Support text/plain content type

### DIFF
--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -143,7 +143,7 @@ func (hs *HandlerFactory) RouteHandler(route *Route) http.HandlerFunc {
 				}
 			case strings.HasPrefix(strings.ToLower(contentType), "plain/text"):
 			default:
-				return 415, i18n.NewError(req.Context(), i18n.MsgInvalidContentType)
+				return 415, i18n.NewError(req.Context(), i18n.MsgInvalidContentType, contentType)
 			}
 		}
 

--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -141,6 +141,7 @@ func (hs *HandlerFactory) RouteHandler(route *Route) http.HandlerFunc {
 				if jsonInput != nil {
 					err = json.NewDecoder(req.Body).Decode(&jsonInput)
 				}
+			case strings.HasPrefix(strings.ToLower(contentType), "plain/text"):
 			default:
 				return 415, i18n.NewError(req.Context(), i18n.MsgInvalidContentType)
 			}

--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -141,7 +141,7 @@ func (hs *HandlerFactory) RouteHandler(route *Route) http.HandlerFunc {
 				if jsonInput != nil {
 					err = json.NewDecoder(req.Body).Decode(&jsonInput)
 				}
-			case strings.HasPrefix(strings.ToLower(contentType), "plain/text"):
+			case strings.HasPrefix(strings.ToLower(contentType), "text/plain"):
 			default:
 				return 415, i18n.NewError(req.Context(), i18n.MsgInvalidContentType, contentType)
 			}

--- a/pkg/i18n/en_base_error_messages.go
+++ b/pkg/i18n/en_base_error_messages.go
@@ -94,7 +94,7 @@ var (
 	MsgRouteDescriptionMissing                     = ffe("FF00159", "API route description missing for route '%s'")
 	MsgFFStructTagMissing                          = ffe("FF00160", "ffstruct tag is missing for '%s' on route '%s'")
 	MsgMultiPartFormReadError                      = ffe("FF00161", "Error reading multi-part form input", 400)
-	MsgInvalidContentType                          = ffe("FF00162", "Invalid content type", 415)
+	MsgInvalidContentType                          = ffe("FF00162", "Invalid content type '%s'", 415)
 	MsgFieldsAfterFile                             = ffe("FF00163", "Additional form field sent after file in multi-part form (ignored): '%s'", 400)
 	Msg404NoResult                                 = ffe("FF00164", "No result found", 404)
 	MsgResponseMarshalError                        = ffe("FF00165", "Failed to serialize response data", 400)


### PR DESCRIPTION
Useful for APIs that relies on envelope based authentication, for instance in many decentralized identity frameworks, which may become part of FireFly in the future.