### PR TITLE
Add text/plain content type support

### DIFF
--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -141,8 +141,9 @@ func (hs *HandlerFactory) RouteHandler(route *Route) http.HandlerFunc {
 				if jsonInput != nil {
 					err = json.NewDecoder(req.Body).Decode(&jsonInput)
 				}
+			case strings.HasPrefix(strings.ToLower(contentType), "text/plain"):
 			default:
-				return 415, i18n.NewError(req.Context(), i18n.MsgInvalidContentType)
+				return 415, i18n.NewError(req.Context(), i18n.MsgInvalidContentType, contentType)
 			}
 		}
 

--- a/pkg/ffapi/handler_test.go
+++ b/pkg/ffapi/handler_test.go
@@ -402,6 +402,41 @@ func TestMultipartBadData(t *testing.T) {
 	assert.Regexp(t, "FF00161", resJSON["error"])
 }
 
+func TestTextPlain201(t *testing.T) {
+	s, _, done := newTestServer(t, []*Route{{
+		Name:   "testRoute",
+		Path:   "/test/{something}",
+		Method: "POST",
+		PathParams: []*PathParam{
+			{Name: "something"},
+		},
+		QueryParams: []*QueryParam{
+			{Name: "param1"},
+			{Name: "param2", IsBool: true},
+			{Name: "param3", IsBool: true},
+		},
+		JSONInputValue:  nil,
+		JSONOutputValue: func() interface{} { return make(map[string]interface{}) },
+		JSONOutputCodes: []int{201},
+		JSONHandler: func(r *APIRequest) (output interface{}, err error) {
+			assert.Equal(t, "stuff", r.PP["something"])
+			assert.Equal(t, "thing", r.QP["param1"])
+			assert.Equal(t, "true", r.QP["param2"])
+			assert.Equal(t, "false", r.QP["param3"])
+			return map[string]interface{}{"output1": "value2"}, nil
+		},
+	}})
+	defer done()
+
+	b := []byte("this is some sample text")
+	res, err := http.Post(fmt.Sprintf("http://%s/test/stuff?param1=thing&param2&param3=false", s.Addr()), "text/plain", bytes.NewReader(b))
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res.StatusCode)
+	var resJSON map[string]interface{}
+	json.NewDecoder(res.Body).Decode(&resJSON)
+	assert.Equal(t, "value2", resJSON["output1"])
+}
+
 func TestMultipartBadContentType(t *testing.T) {
 	hf := newTestHandlerFactory()
 	_, err := hf.getFilePart(httptest.NewRequest("GET", "/wrong", nil))

--- a/pkg/i18n/en_base_error_messages.go
+++ b/pkg/i18n/en_base_error_messages.go
@@ -94,7 +94,7 @@ var (
 	MsgRouteDescriptionMissing                     = ffe("FF00159", "API route description missing for route '%s'")
 	MsgFFStructTagMissing                          = ffe("FF00160", "ffstruct tag is missing for '%s' on route '%s'")
 	MsgMultiPartFormReadError                      = ffe("FF00161", "Error reading multi-part form input", 400)
-	MsgInvalidContentType                          = ffe("FF00162", "Invalid content type", 415)
+	MsgInvalidContentType                          = ffe("FF00162", "Invalid content type '%s'", 415)
 	MsgFieldsAfterFile                             = ffe("FF00163", "Additional form field sent after file in multi-part form (ignored): '%s'", 400)
 	Msg404NoResult                                 = ffe("FF00164", "No result found", 404)
 	MsgResponseMarshalError                        = ffe("FF00165", "Failed to serialize response data", 400)


### PR DESCRIPTION
Useful for APIs that relies on envelope based authentication, for instance in many decentralized identity frameworks, which may become part of FireFly in the future.