### PR TITLE
feat: Add nested array config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -354,20 +354,11 @@ func (c *configSection) SubArray(name string) ArraySection {
 }
 
 func (c *configArray) SubArray(name string) ArraySection {
-	a := &configArray{
+	return &configArray{
 		base:     keyName(c.base+"[]", name),
 		parent:   c,
 		defaults: make(map[string][]interface{}),
 	}
-	// Get defaults from any enclosing array entry, and copy over any applicable to this subtree
-	// This is necessary to propagate known keys for arrays within arrays
-	prefix := a.base + "[]."
-	for key, val := range getArrayEntryDefaults(c) {
-		if strings.HasPrefix(key, prefix) {
-			a.defaults[strings.TrimPrefix(key, prefix)] = val
-		}
-	}
-	return a
 }
 
 func (c *configArray) ArraySize() int {


### PR DESCRIPTION
As part of another feature I want to be able to add nested arrays such as:
```
namespaces:
  predefined:
  - name: myns
    tlsConfigs:
    - name: myconfig
      tls:
        enabled: true
```

This is not currently possible and this PR adds that support. Let me know if I missed out on anything!