### PR TITLE
Add configurable connection timeout for WebSocket client

### DIFF
--- a/pkg/i18n/en_base_config_descriptions.go
+++ b/pkg/i18n/en_base_config_descriptions.go
@@ -58,6 +58,7 @@ var (
 	ConfigGlobalSize = ffc("config.global.cache.size", "The size of the cache", ByteSizeType)
 	ConfigGlobalTTL  = ffc("config.global.cache.ttl", "The time to live (TTL) for the cache", TimeDurationType)
 
+	ConfigGlobalWsConnectionTimeout      = ffc("config.global.ws.connectionTimeout", "The amount of time to wait while establishing a connection (or auto-reconnection)", TimeDurationType)
 	ConfigGlobalWsHeartbeatInterval      = ffc("config.global.ws.heartbeatInterval", "The amount of time to wait between heartbeat signals on the WebSocket connection", TimeDurationType)
 	ConfigGlobalWsInitialConnectAttempts = ffc("config.global.ws.initialConnectAttempts", "The number of attempts FireFly will make to connect to the WebSocket when starting up, before failing", IntType)
 	ConfigGlobalWsPath                   = ffc("config.global.ws.path", "The WebSocket sever URL to which FireFly should connect", "WebSocket URL "+StringType)

--- a/pkg/wsclient/wsclient.go
+++ b/pkg/wsclient/wsclient.go
@@ -48,6 +48,7 @@ type WSConfig struct {
 	HTTPHeaders            fftypes.JSONObject `json:"headers,omitempty"`
 	HeartbeatInterval      time.Duration      `json:"heartbeatInterval,omitempty"`
 	TLSClientConfig        *tls.Config        `json:"tlsClientConfig,omitempty"`
+	ConnectionTimeout      time.Duration      `json:"connectionTimeout,omitempty"`
 	// This one cannot be set in JSON - must be configured on the code interface
 	ReceiveExt bool
 }
@@ -124,9 +125,10 @@ func New(ctx context.Context, config *WSConfig, beforeConnect WSPreConnectHandle
 		ctx: ctx,
 		url: wsURL,
 		wsdialer: &websocket.Dialer{
-			ReadBufferSize:  config.ReadBufferSize,
-			WriteBufferSize: config.WriteBufferSize,
-			TLSClientConfig: config.TLSClientConfig,
+			ReadBufferSize:   config.ReadBufferSize,
+			WriteBufferSize:  config.WriteBufferSize,
+			TLSClientConfig:  config.TLSClientConfig,
+			HandshakeTimeout: config.ConnectionTimeout,
 		},
 		retry: retry.Retry{
 			InitialDelay: config.InitialDelay,


### PR DESCRIPTION
The underlying WebSocket client library that we are using supports a connection timeout, but we previously did not expose a way to configure it. The default was 45 seconds, which is too long for the firefly-perf-cli as it normally only gives 30 seconds before considering a transaction a failure. This PR adds a configuration option to the websocket client. If the timeout is exceeded and a connection has not been established, the client will automatically try again unless auto reconnections are disabled.