### PR TITLE
Fixing cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -70,8 +70,7 @@ func (c *CCache) Set(key string, val interface{}) {
 }
 func (c *CCache) Get(key string) interface{} {
 	if c.enabled {
-		if cached := c.cache.Get(key); cached != nil {
-			cached.Extend(c.cacheTTL)
+		if cached := c.cache.Get(key); cached != nil && !cached.Expired() {
 			return cached.Value()
 		}
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -95,7 +95,7 @@ func (c *CCache) GetString(key string) string {
 	if c.enabled {
 		val := c.Get(key)
 		if val != nil {
-			return c.Get(key).(string)
+			return val.(string)
 		}
 	}
 	return ""
@@ -111,7 +111,7 @@ func (c *CCache) GetInt(key string) int {
 	if c.enabled {
 		val := c.Get(key)
 		if val != nil {
-			return c.Get(key).(int)
+			return val.(int)
 		}
 	}
 	return 0
@@ -127,7 +127,7 @@ func (c *CCache) GetInt64(key string) int64 {
 	if c.enabled {
 		val := c.Get(key)
 		if val != nil {
-			return c.Get(key).(int64)
+			return val.(int64)
 		}
 	}
 	return 0

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -60,6 +60,17 @@ func TestTwoSeparateCacheWorksIndependently(t *testing.T) {
 	assert.Equal(t, nil, cache1.Get("string1"))
 }
 
+func TestTTL(t *testing.T) {
+	ctx := context.Background()
+	cacheManager := NewCacheManager(ctx, true)
+	cache0, _ := cacheManager.GetCache(ctx, "ns1", "cacheA", 85, time.Second/2, true)
+
+	cache0.Set("int0", 100)
+	assert.Equal(t, 100, cache0.Get("int0"))
+
+	time.Sleep(time.Second)
+	assert.Nil(t, cache0.Get("int0"))
+}
 func TestCacheEnablement(t *testing.T) {
 	ctx := context.Background()
 	var hundred int64 = 100

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -68,7 +68,11 @@ func TestTTL(t *testing.T) {
 	cache0.Set("int0", 100)
 	assert.Equal(t, 100, cache0.Get("int0"))
 
-	time.Sleep(time.Second)
+	time.Sleep(time.Second / 3)
+	assert.Equal(t, 100, cache0.Get("int0"))
+
+	time.Sleep(time.Second / 3)
+
 	assert.Nil(t, cache0.Get("int0"))
 }
 func TestCacheEnablement(t *testing.T) {


### PR DESCRIPTION
The existing cache logic is not aware of TTL. So I don't believe TTL configuration in caching ever worked.

https://github.com/karlseguin/ccache#get Here is the explanation of why the `Get` method from ccache returns expired values.


I also found that we were extending the TTL of an item on all the `Get` calls. I couldn't figure out why it was needed. It was there before the refactor: https://github.com/hyperledger/firefly/pull/1005/files#diff-980438bfe0743cd28ea9e330bee535be87f8de11bc8cdc83595046f9a0fb2144L862

I propose we remove it and added test for the new behaviour