### PR TITLE
Add extra HTTP client / retry options

### DIFF
--- a/pkg/ffresty/config.go
+++ b/pkg/ffresty/config.go
@@ -31,6 +31,7 @@ const (
 	defaultRequestTimeout                = "30s"
 	defaultHTTPIdleTimeout               = "475ms" // Node.js default keepAliveTimeout is 5 seconds, so we have to set a base below this
 	defaultHTTPMaxIdleConns              = 100     // match Go's default
+	defaultHTTPMaxConnsPerHost           = 0
 	defaultHTTPConnectionTimeout         = "30s"
 	defaultHTTPTLSHandshakeTimeout       = "10s" // match Go's default
 	defaultHTTPExpectContinueTimeout     = "1s"  // match Go's default
@@ -62,6 +63,8 @@ const (
 	HTTPIdleTimeout = "idleTimeout"
 	// HTTPMaxIdleConns the max number of idle connections to hold pooled
 	HTTPMaxIdleConns = "maxIdleConns"
+	// HTTPMaxConnsPerHost the max number of concurrent connections
+	HTTPMaxConnsPerHost = "maxConnsPerHost"
 	// HTTPConnectionTimeout the connection timeout for new connections
 	HTTPConnectionTimeout = "connectionTimeout"
 	// HTTPTLSHandshakeTimeout the TLS handshake connection timeout
@@ -88,6 +91,7 @@ func InitConfig(conf config.Section) {
 	conf.AddKnownKey(HTTPConfigRequestTimeout, defaultRequestTimeout)
 	conf.AddKnownKey(HTTPIdleTimeout, defaultHTTPIdleTimeout)
 	conf.AddKnownKey(HTTPMaxIdleConns, defaultHTTPMaxIdleConns)
+	conf.AddKnownKey(HTTPMaxConnsPerHost, defaultHTTPMaxConnsPerHost)
 	conf.AddKnownKey(HTTPConnectionTimeout, defaultHTTPConnectionTimeout)
 	conf.AddKnownKey(HTTPTLSHandshakeTimeout, defaultHTTPTLSHandshakeTimeout)
 	conf.AddKnownKey(HTTPExpectContinueTimeout, defaultHTTPExpectContinueTimeout)

--- a/pkg/ffresty/ffresty.go
+++ b/pkg/ffresty/ffresty.go
@@ -226,8 +226,8 @@ func NewWithConfig(ctx context.Context, ffrestyConfig Config) (client *resty.Cli
 					log.L(rCtx).Debugf("retry cancelled after %d attempts", rc.attempts)
 					return false
 				}
-				log.L(rCtx).Infof("retry %d/%d (min=%dms/max=%dms) status=%d", rc.attempts, retryCount, minTimeout.Milliseconds(), maxTimeout.Milliseconds(), r.StatusCode())
 				rc.attempts++
+				log.L(rCtx).Infof("retry %d/%d (min=%dms/max=%dms) status=%d", rc.attempts, retryCount, minTimeout.Milliseconds(), maxTimeout.Milliseconds(), r.StatusCode())
 				return true
 			})
 	}

--- a/pkg/ffresty/ffresty.go
+++ b/pkg/ffresty/ffresty.go
@@ -59,6 +59,7 @@ type Config struct {
 	RetryInitialDelay             time.Duration                             `json:"retryInitialDelay,omitempty"`
 	RetryMaximumDelay             time.Duration                             `json:"retryMaximumDelay,omitempty"`
 	HTTPMaxIdleConns              int                                       `json:"maxIdleConns,omitempty"`
+	HTTPMaxConnsPerHost           int                                       `json:"maxConnsPerHost,omitempty"`
 	HTTPPassthroughHeadersEnabled bool                                      `json:"httpPassthroughHeadersEnabled,omitempty"`
 	HTTPHeaders                   fftypes.JSONObject                        `json:"headers,omitempty"`
 	TLSClientConfig               *tls.Config                               `json:"tlsClientConfig,omitempty"`
@@ -123,6 +124,7 @@ func NewWithConfig(ctx context.Context, ffrestyConfig Config) (client *resty.Cli
 			}).DialContext,
 			ForceAttemptHTTP2:     true,
 			MaxIdleConns:          ffrestyConfig.HTTPMaxIdleConns,
+			MaxConnsPerHost:       ffrestyConfig.HTTPMaxConnsPerHost,
 			IdleConnTimeout:       ffrestyConfig.HTTPIdleConnTimeout,
 			TLSHandshakeTimeout:   ffrestyConfig.HTTPTLSHandshakeTimeout,
 			ExpectContinueTimeout: ffrestyConfig.HTTPExpectContinueTimeout,

--- a/pkg/ffresty/ffresty.go
+++ b/pkg/ffresty/ffresty.go
@@ -45,25 +45,27 @@ type retryCtx struct {
 }
 
 type Config struct {
-	URL                           string             `json:"httpURL,omitempty"`
-	ProxyURL                      string             `json:"proxyURL,omitempty"`
-	HTTPRequestTimeout            time.Duration      `json:"requestTimeout,omitempty"`
-	HTTPIdleConnTimeout           time.Duration      `json:"idleTimeout,omitempty"`
-	HTTPMaxIdleTimeout            time.Duration      `json:"maxIdleTimeout,omitempty"`
-	HTTPConnectionTimeout         time.Duration      `json:"connectionTimeout,omitempty"`
-	HTTPExpectContinueTimeout     time.Duration      `json:"expectContinueTimeout,omitempty"`
-	AuthUsername                  string             `json:"authUsername,omitempty"`
-	AuthPassword                  string             `json:"authPassword,omitempty"`
-	Retry                         bool               `json:"retry,omitempty"`
-	RetryCount                    int                `json:"retryCount,omitempty"`
-	RetryInitialDelay             time.Duration      `json:"retryInitialDelay,omitempty"`
-	RetryMaximumDelay             time.Duration      `json:"retryMaximumDelay,omitempty"`
-	HTTPMaxIdleConns              int                `json:"maxIdleConns,omitempty"`
-	HTTPPassthroughHeadersEnabled bool               `json:"httpPassthroughHeadersEnabled,omitempty"`
-	HTTPHeaders                   fftypes.JSONObject `json:"headers,omitempty"`
-	TLSClientConfig               *tls.Config        `json:"tlsClientConfig,omitempty"`
-	HTTPTLSHandshakeTimeout       time.Duration      `json:"tlsHandshakeTimeout,omitempty"`
-	HTTPCustomClient              interface{}        `json:"httpCustomClient,omitempty"`
+	URL                           string                                    `json:"httpURL,omitempty"`
+	ProxyURL                      string                                    `json:"proxyURL,omitempty"`
+	HTTPRequestTimeout            time.Duration                             `json:"requestTimeout,omitempty"`
+	HTTPIdleConnTimeout           time.Duration                             `json:"idleTimeout,omitempty"`
+	HTTPMaxIdleTimeout            time.Duration                             `json:"maxIdleTimeout,omitempty"`
+	HTTPConnectionTimeout         time.Duration                             `json:"connectionTimeout,omitempty"`
+	HTTPExpectContinueTimeout     time.Duration                             `json:"expectContinueTimeout,omitempty"`
+	AuthUsername                  string                                    `json:"authUsername,omitempty"`
+	AuthPassword                  string                                    `json:"authPassword,omitempty"`
+	Retry                         bool                                      `json:"retry,omitempty"`
+	RetryCount                    int                                       `json:"retryCount,omitempty"`
+	RetryInitialDelay             time.Duration                             `json:"retryInitialDelay,omitempty"`
+	RetryMaximumDelay             time.Duration                             `json:"retryMaximumDelay,omitempty"`
+	HTTPMaxIdleConns              int                                       `json:"maxIdleConns,omitempty"`
+	HTTPPassthroughHeadersEnabled bool                                      `json:"httpPassthroughHeadersEnabled,omitempty"`
+	HTTPHeaders                   fftypes.JSONObject                        `json:"headers,omitempty"`
+	TLSClientConfig               *tls.Config                               `json:"tlsClientConfig,omitempty"`
+	HTTPTLSHandshakeTimeout       time.Duration                             `json:"tlsHandshakeTimeout,omitempty"`
+	HTTPCustomClient              interface{}                               `json:"httpCustomClient,omitempty"`
+	OnCheckRetry                  func(res *resty.Response, err error) bool `json:"-"` // response could be nil on err
+	OnBeforeRequest               func(req *resty.Request) error            `json:"-"` // called before each request, even retry
 }
 
 // OnAfterResponse when using SetDoNotParseResponse(true) for streaming binary replies,
@@ -181,6 +183,12 @@ func NewWithConfig(ctx context.Context, ffrestyConfig Config) (client *resty.Cli
 			req.Header.Set(ffapi.FFRequestIDHeader, ffRequestID.(string))
 		}
 
+		if ffrestyConfig.OnBeforeRequest != nil {
+			if err := ffrestyConfig.OnBeforeRequest(req); err != nil {
+				return err
+			}
+		}
+
 		log.L(rCtx).Debugf("==> %s %s%s", req.Method, url, req.URL)
 		return nil
 	})
@@ -212,6 +220,10 @@ func NewWithConfig(ctx context.Context, ffrestyConfig Config) (client *resty.Cli
 				}
 				rCtx := r.Request.Context()
 				rc := rCtx.Value(retryCtxKey{}).(*retryCtx)
+				if ffrestyConfig.OnCheckRetry != nil && !ffrestyConfig.OnCheckRetry(r, err) {
+					log.L(rCtx).Debugf("retry cancelled after %d attempts", rc.attempts)
+					return false
+				}
 				log.L(rCtx).Infof("retry %d/%d (min=%dms/max=%dms) status=%d", rc.attempts, retryCount, minTimeout.Milliseconds(), maxTimeout.Milliseconds(), r.StatusCode())
 				rc.attempts++
 				return true

--- a/pkg/i18n/en_base_config_descriptions.go
+++ b/pkg/i18n/en_base_config_descriptions.go
@@ -79,6 +79,7 @@ var (
 	ConfigGlobalHeaders                   = ffc("config.global.headers", "Adds custom headers to HTTP requests", MapStringStringType)
 	ConfigGlobalIdleTimeout               = ffc("config.global.idleTimeout", "The max duration to hold a HTTP keepalive connection between calls", TimeDurationType)
 	ConfigGlobalMaxIdleConns              = ffc("config.global.maxIdleConns", "The max number of idle connections to hold pooled", IntType)
+	ConfigGlobalMaxConnsPerHost           = ffc("config.global.maxConnsPerHost", "The max number of connections, per unique hostname. Zero means no limit", IntType)
 	ConfigGlobalMethod                    = ffc("config.global.method", "The HTTP method to use when making requests to the Address Resolver", StringType)
 	ConfigGlobalAuthType                  = ffc("config.global.auth.type", "The auth plugin to use for server side authentication of requests", StringType)
 	ConfigGlobalPassthroughHeadersEnabled = ffc("config.global.passthroughHeadersEnabled", "Enable passing through the set of allowed HTTP request headers", BooleanType)


### PR DESCRIPTION
Have a use case where I need to:
1. Generate a new piece of data on each retry (a header has to be updated each time)
2. Do some special checking on status codes etc. to determine if retry is suitable
3. Limit the number of concurrent HTTP socket connections to a host