### PR TITLE
config for always returning pagination response

### DIFF
--- a/pkg/ffapi/apirequest.go
+++ b/pkg/ffapi/apirequest.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -31,17 +31,24 @@ type APIRequest struct {
 	Part            *Multipart
 	SuccessStatus   int
 	ResponseHeaders http.Header
+	AlwaysPaginate  bool
 }
 
 // FilterResult is a helper to transform a filter result into a REST API standard payload
 func (r *APIRequest) FilterResult(items interface{}, res *FilterResult, err error) (interface{}, error) {
 	itemsVal := reflect.ValueOf(items)
-	if err != nil || res == nil || res.TotalCount == nil || itemsVal.Kind() != reflect.Slice {
-		return items, err
+	if itemsVal.Kind() == reflect.Slice && (r.AlwaysPaginate || (res != nil && res.TotalCount != nil)) {
+		response := &FilterResultsWithCount{
+			Items: items,
+		}
+		if res != nil && res.TotalCount != nil {
+			response.Total = *res.TotalCount
+		}
+		if itemsVal.Kind() == reflect.Slice {
+			response.Count = int64(itemsVal.Len())
+		}
+		return response, err
 	}
-	return &FilterResultsWithCount{
-		Total: *res.TotalCount,
-		Count: int64(itemsVal.Len()),
-		Items: items,
-	}, nil
+	return items, err
+
 }

--- a/pkg/ffapi/apirequest_test.go
+++ b/pkg/ffapi/apirequest_test.go
@@ -42,3 +42,36 @@ func TestFilterResultPlain(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"test"}, f)
 }
+
+func TestFilterResultWithCountNoTotal(t *testing.T) {
+	r := &APIRequest{
+		AlwaysPaginate: true,
+	}
+	f, err := r.FilterResult([]string{"test"}, &FilterResult{}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, &FilterResultsWithCount{
+		Count: 1,
+		Items: []string{"test"},
+	}, f)
+}
+
+func TestFilterResultAlwyasPaginateNoSlice(t *testing.T) {
+	r := &APIRequest{
+		AlwaysPaginate: true,
+	}
+	f, err := r.FilterResult("test", &FilterResult{}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "test", f)
+}
+
+func TestFilterResultAlwaysPaginateNoFilterResult(t *testing.T) {
+	r := &APIRequest{
+		AlwaysPaginate: true,
+	}
+	f, err := r.FilterResult([]string{"test"}, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, &FilterResultsWithCount{
+		Count: 1,
+		Items: []string{"test"},
+	}, f)
+}

--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -59,6 +59,7 @@ type apiServer[T any] struct {
 	requestTimeout     time.Duration
 	requestMaxTimeout  time.Duration
 	apiPublicURL       string
+	alwaysPaginate     bool
 	metricsEnabled     bool
 	metricsPath        string
 	metricsPublicURL   string
@@ -93,6 +94,7 @@ func NewAPIServer[T any](ctx context.Context, options APIServerOptions[T]) APISe
 		maxFilterSkip:      options.APIConfig.GetUint64(ConfAPIMaxFilterSkip),
 		requestTimeout:     options.APIConfig.GetDuration(ConfAPIRequestTimeout),
 		requestMaxTimeout:  options.APIConfig.GetDuration(ConfAPIRequestMaxTimeout),
+		alwaysPaginate:     options.APIConfig.GetBool(ConfAPIAlwaysPaginate),
 		metricsEnabled:     options.MetricsConfig.GetBool(ConfMetricsServerEnabled),
 		metricsPath:        options.MetricsConfig.GetString(ConfMetricsServerPath),
 		APIServerOptions:   options,
@@ -236,6 +238,7 @@ func (as *apiServer[T]) handlerFactory() *HandlerFactory {
 	return &HandlerFactory{
 		DefaultRequestTimeout: as.requestTimeout,
 		MaxTimeout:            as.requestMaxTimeout,
+		AlwaysPaginate:        as.alwaysPaginate,
 	}
 }
 

--- a/pkg/ffapi/apiserver_config.go
+++ b/pkg/ffapi/apiserver_config.go
@@ -30,6 +30,7 @@ var (
 	ConfAPIMaxFilterSkip      = "maxFilterSkip"
 	ConfAPIRequestTimeout     = "requestTimeout"
 	ConfAPIRequestMaxTimeout  = "requestMaxTimeout"
+	ConfAPIAlwaysPaginate     = "alwaysPaginate"
 )
 
 func InitAPIServerConfig(apiConfig, metricsConfig, corsConfig config.Section) {
@@ -39,6 +40,7 @@ func InitAPIServerConfig(apiConfig, metricsConfig, corsConfig config.Section) {
 	apiConfig.AddKnownKey(ConfAPIMaxFilterSkip, 100000)
 	apiConfig.AddKnownKey(ConfAPIRequestTimeout, "30s")
 	apiConfig.AddKnownKey(ConfAPIRequestMaxTimeout, "10m")
+	apiConfig.AddKnownKey(ConfAPIAlwaysPaginate, false)
 
 	httpserver.InitCORSConfig(corsConfig)
 

--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -48,6 +48,7 @@ type HandlerFactory struct {
 	MaxFilterSkip         uint64
 	MaxFilterLimit        uint64
 	PassthroughHeaders    []string
+	AlwaysPaginate        bool
 }
 
 var ffMsgCodeExtractor = regexp.MustCompile(`^(FF\d+):`)
@@ -171,6 +172,7 @@ func (hs *HandlerFactory) RouteHandler(route *Route) http.HandlerFunc {
 				Input:           jsonInput,
 				SuccessStatus:   http.StatusOK,
 				ResponseHeaders: res.Header(),
+				AlwaysPaginate:  hs.AlwaysPaginate,
 			}
 			if len(route.JSONOutputCodes) > 0 {
 				r.SuccessStatus = route.JSONOutputCodes[0]


### PR DESCRIPTION
The structure of an array response is currently dependant on the query parameters. If `count=true` is specified, then the response is a pagination object wrapping the array and containing count and total.  Otherwise, the response is the bare JSON array.

The bare array is nice and easy to consume but it may be undesirable in certain situations to lull the developer into expecting a bare array and suddenly realising that once the collection contains so many items, that it will be paginated and the response structure suddenly changes.

This PR proposes to give the deployer of any service using firefly-common to configure it such that the pagination response structure is always used regardless of whether pagination filter was requested or whether or not the total number of records is available.