### PR TITLE
convert int value unset log to trace

### DIFF
--- a/pkg/fftypes/jsonobject.go
+++ b/pkg/fftypes/jsonobject.go
@@ -61,7 +61,7 @@ func (jd JSONObject) GetString(key string) string {
 func (jd JSONObject) GetInteger(key string) *big.Int {
 	s := jd.GetString(key)
 	if s == "" {
-		log.L(context.Background()).Debugf("Int value unset for key '%s'", key)
+		log.L(context.Background()).Tracef("Int value unset for key '%s'", key)
 		return big.NewInt(0)
 	}
 	i, ok := big.NewInt(0).SetString(s, 0)


### PR DESCRIPTION
As described in the title, I'm using the behaviour of getting the 0 big.Int back when the string is empty, it starts to become annoying to see this log line at debug level.
