### PR TITLE
Add field selection on GetMany and tweaks to Filter API builder pattern

### DIFF
--- a/pkg/dbsql/filter_sql_test.go
+++ b/pkg/dbsql/filter_sql_test.go
@@ -170,7 +170,7 @@ func TestSQLQueryFactoryFinalizeFail(t *testing.T) {
 func TestSQLQueryFactoryBadOp(t *testing.T) {
 
 	s, _ := NewMockProvider().UTInit()
-	_, err := s.filterSelectFinalized(context.Background(), "", &ffapi.FilterInfo{
+	_, err := s.refineQuery(context.Background(), "", &ffapi.FilterInfo{
 		Op: ffapi.FilterOp("wrong"),
 	}, nil)
 	assert.Regexp(t, "FF00190.*wrong", err)
@@ -179,7 +179,7 @@ func TestSQLQueryFactoryBadOp(t *testing.T) {
 func TestSQLQueryFactoryBadOpInOr(t *testing.T) {
 
 	s, _ := NewMockProvider().UTInit()
-	_, err := s.filterSelectFinalized(context.Background(), "", &ffapi.FilterInfo{
+	_, err := s.refineQuery(context.Background(), "", &ffapi.FilterInfo{
 		Op: ffapi.FilterOpOr,
 		Children: []*ffapi.FilterInfo{
 			{Op: ffapi.FilterOp("wrong")},
@@ -191,7 +191,7 @@ func TestSQLQueryFactoryBadOpInOr(t *testing.T) {
 func TestSQLQueryFactoryBadOpInAnd(t *testing.T) {
 
 	s, _ := NewMockProvider().UTInit()
-	_, err := s.filterSelectFinalized(context.Background(), "", &ffapi.FilterInfo{
+	_, err := s.refineQuery(context.Background(), "", &ffapi.FilterInfo{
 		Op: ffapi.FilterOpAnd,
 		Children: []*ffapi.FilterInfo{
 			{Op: ffapi.FilterOp("wrong")},

--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -77,6 +77,7 @@ type APIServerOptions[T any] struct {
 	FavIcon16                 []byte
 	FavIcon32                 []byte
 	PanicOnMissingDescription bool
+	SupportFieldRedaction     bool
 }
 
 type APIServerRouteExt[T any] struct {
@@ -88,15 +89,12 @@ type APIServerRouteExt[T any] struct {
 // the supplied wrapper function - which will inject
 func NewAPIServer[T any](ctx context.Context, options APIServerOptions[T]) APIServer {
 	as := &apiServer[T]{
-		defaultFilterLimit: options.APIConfig.GetUint64(ConfAPIDefaultFilterLimit),
-		maxFilterLimit:     options.APIConfig.GetUint64(ConfAPIMaxFilterLimit),
-		maxFilterSkip:      options.APIConfig.GetUint64(ConfAPIMaxFilterSkip),
-		requestTimeout:     options.APIConfig.GetDuration(ConfAPIRequestTimeout),
-		requestMaxTimeout:  options.APIConfig.GetDuration(ConfAPIRequestMaxTimeout),
-		metricsEnabled:     options.MetricsConfig.GetBool(ConfMetricsServerEnabled),
-		metricsPath:        options.MetricsConfig.GetString(ConfMetricsServerPath),
-		APIServerOptions:   options,
-		started:            make(chan struct{}),
+		requestTimeout:    options.APIConfig.GetDuration(ConfAPIRequestTimeout),
+		requestMaxTimeout: options.APIConfig.GetDuration(ConfAPIRequestMaxTimeout),
+		metricsEnabled:    options.MetricsConfig.GetBool(ConfMetricsServerEnabled),
+		metricsPath:       options.MetricsConfig.GetString(ConfMetricsServerPath),
+		APIServerOptions:  options,
+		started:           make(chan struct{}),
 	}
 	if as.FavIcon16 == nil {
 		as.FavIcon16 = ffLogo16
@@ -189,6 +187,7 @@ func (as *apiServer[T]) swaggerGenConf(apiBaseURL string) *Options {
 		Version:                   "1.0",
 		PanicOnMissingDescription: as.PanicOnMissingDescription,
 		DefaultRequestTimeout:     as.requestTimeout,
+		SupportFieldRedaction:     as.SupportFieldRedaction,
 	}
 }
 
@@ -236,6 +235,10 @@ func (as *apiServer[T]) handlerFactory() *HandlerFactory {
 	return &HandlerFactory{
 		DefaultRequestTimeout: as.requestTimeout,
 		MaxTimeout:            as.requestMaxTimeout,
+		DefaultFilterLimit:    as.defaultFilterLimit,
+		MaxFilterSkip:         as.maxFilterSkip,
+		MaxFilterLimit:        as.maxFilterLimit,
+		SupportFieldRedaction: as.SupportFieldRedaction,
 	}
 }
 

--- a/pkg/ffapi/filter_test.go
+++ b/pkg/ffapi/filter_test.go
@@ -41,9 +41,10 @@ func TestBuildMessageFilter(t *testing.T) {
 		Sort("tag").
 		Descending().
 		GroupBy("type").
+		RequiredFields("type", "created").
 		Finalize()
 	assert.NoError(t, err)
-	assert.Equal(t, "( tag == 'tag1' ) && ( ( id == '35c11cba-adff-4a4d-970a-02e3a0858dc8' ) || ( id == 'caefb9d1-9fc9-4d6a-a155-514d3139adf7' ) ) && ( sequence >> 12345 ) && ( created == null ) groupBy=type sort=-tag skip=50 limit=25 count=true", f.String())
+	assert.Equal(t, "( tag == 'tag1' ) && ( ( id == '35c11cba-adff-4a4d-970a-02e3a0858dc8' ) || ( id == 'caefb9d1-9fc9-4d6a-a155-514d3139adf7' ) ) && ( sequence >> 12345 ) && ( created == null ) groupBy=type requiredFields=type,created sort=-tag skip=50 limit=25 count=true", f.String())
 }
 
 func TestBuildMessageFilter2(t *testing.T) {
@@ -59,22 +60,23 @@ func TestBuildMessageFilter2(t *testing.T) {
 
 func TestBuildMessageFilter3(t *testing.T) {
 	fb := TestQueryFactory.NewFilter(context.Background())
-	f, err := fb.And(
-		fb.In("created", []driver.Value{1, 2, 3}),
-		fb.NotIn("created", []driver.Value{1, 2, 3}),
-		fb.Lt("created", "0"),
-		fb.Lte("created", "0"),
-		fb.Gte("created", "0"),
-		fb.Neq("created", "0"),
-		fb.Gt("sequence", 12345),
-		fb.Contains("topics", "abc"),
-		fb.NotContains("topics", "def"),
-		fb.IContains("topics", "ghi"),
-		fb.NotIContains("topics", "jkl"),
-	).
+	f, err := fb.
 		Sort("-created").
 		Sort("topics").
 		Sort("-sequence").
+		And(
+			fb.In("created", []driver.Value{1, 2, 3}),
+			fb.NotIn("created", []driver.Value{1, 2, 3}),
+			fb.Lt("created", "0"),
+			fb.Lte("created", "0"),
+			fb.Gte("created", "0"),
+			fb.Neq("created", "0"),
+			fb.Gt("sequence", 12345),
+			fb.Contains("topics", "abc"),
+			fb.NotContains("topics", "def"),
+			fb.IContains("topics", "ghi"),
+			fb.NotIContains("topics", "jkl"),
+		).
 		Finalize()
 	assert.NoError(t, err)
 	assert.Equal(t, "( created IN [1000000000,2000000000,3000000000] ) && ( created NI [1000000000,2000000000,3000000000] ) && ( created << 0 ) && ( created <= 0 ) && ( created >= 0 ) && ( created != 0 ) && ( sequence >> 12345 ) && ( topics %= 'abc' ) && ( topics !% 'def' ) && ( topics :% 'ghi' ) && ( topics ;% 'jkl' ) sort=-created,topics,-sequence", f.String())

--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -48,6 +48,7 @@ type HandlerFactory struct {
 	MaxFilterSkip         uint64
 	MaxFilterLimit        uint64
 	PassthroughHeaders    []string
+	SupportFieldRedaction bool
 }
 
 var ffMsgCodeExtractor = regexp.MustCompile(`^(FF\d+):`)

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -45,6 +45,7 @@ type Options struct {
 	APIMaxFilterSkip          uint
 	APIDefaultFilterLimit     string
 	APIMaxFilterLimit         uint
+	SupportFieldRedaction     bool
 
 	RouteCustomizations func(ctx context.Context, sg *SwaggerGen, route *Route, op *openapi3.Operation)
 }
@@ -323,6 +324,9 @@ func (sg *SwaggerGen) addFilters(ctx context.Context, route *Route, op *openapi3
 		sg.AddParam(ctx, op, "query", "skip", "", "", i18n.APIFilterSkipDesc, false, sg.options.APIMaxFilterSkip)
 		sg.AddParam(ctx, op, "query", "limit", "", sg.options.APIDefaultFilterLimit, i18n.APIFilterLimitDesc, false, sg.options.APIMaxFilterLimit)
 		sg.AddParam(ctx, op, "query", "count", "", "", i18n.APIFilterCountDesc, false)
+		if sg.options.SupportFieldRedaction {
+			sg.AddParam(ctx, op, "query", "fields", "", "", i18n.APIFilterFieldsDesc, false)
+		}
 	}
 }
 

--- a/pkg/ffapi/openapi3_test.go
+++ b/pkg/ffapi/openapi3_test.go
@@ -166,6 +166,7 @@ func TestOpenAPI3SwaggerGen(t *testing.T) {
 		RouteCustomizations: func(ctx context.Context, sg *SwaggerGen, route *Route, op *openapi3.Operation) {
 			sg.AddParam(ctx, op, "header", "x-my-param", "thing", "stuff", ExampleDesc, false)
 		},
+		SupportFieldRedaction: true,
 	}).Generate(context.Background(), testRoutes)
 	err := doc.Validate(context.Background())
 	assert.NoError(t, err)

--- a/pkg/ffapi/restfilter.go
+++ b/pkg/ffapi/restfilter.go
@@ -113,6 +113,18 @@ func (hs *HandlerFactory) buildFilter(req *http.Request, ff QueryFactory) (AndFi
 			}
 		}
 	}
+	if hs.SupportFieldRedaction {
+		requiredFieldVals := hs.getValues(req.Form, "fields")
+		for _, rf := range requiredFieldVals {
+			subRequiredFieldVals := strings.Split(rf, ",")
+			for _, srf := range subRequiredFieldVals {
+				srf = strings.TrimSpace(srf)
+				if srf != "" {
+					filter.RequiredFields(srf)
+				}
+			}
+		}
+	}
 	descendingVals := hs.getValues(req.Form, "descending")
 	ascendingVals := hs.getValues(req.Form, "ascending")
 	if len(descendingVals) > 0 && (descendingVals[0] == "" || strings.EqualFold(descendingVals[0], "true")) {

--- a/pkg/ffapi/restfilter_test.go
+++ b/pkg/ffapi/restfilter_test.go
@@ -149,3 +149,18 @@ func TestBuildFilterLimitLimit(t *testing.T) {
 	_, err := as.buildFilter(req, TestQueryFactory)
 	assert.Regexp(t, "FF00192.*500", err)
 }
+
+func TestBuildFilterRequiredFields(t *testing.T) {
+	as := &HandlerFactory{
+		MaxFilterLimit:        250,
+		SupportFieldRedaction: true,
+	}
+
+	req := httptest.NewRequest("GET", "/things?created=0&fields=tag,sequence", nil)
+	filter, err := as.buildFilter(req, TestQueryFactory)
+	assert.NoError(t, err)
+	fi, err := filter.Finalize()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "( created == 0 ) requiredFields=tag,sequence", fi.String())
+}

--- a/pkg/i18n/en_base_messages.go
+++ b/pkg/i18n/en_base_messages.go
@@ -34,6 +34,7 @@ var (
 	APIFilterSkipDesc       = ffm("api.filterSkip", "The number of records to skip (max: %d). Unsuitable for bulk operations")
 	APIFilterLimitDesc      = ffm("api.filterLimit", "The maximum number of records to return (max: %d)")
 	APIFilterCountDesc      = ffm("api.filterCount", "Return a total count as well as items (adds extra database processing)")
+	APIFilterFieldsDesc     = ffm("api.filterFields", "Comma separated list of fields to return")
 
 	ResourceBaseID      = ffm("ResourceBase.id", "The UUID of the service")
 	ResourceBaseCreated = ffm("ResourceBase.created", "The time the resource was created")


### PR DESCRIPTION
- Support field-level selection/redaction in `CRUD` only
   - Adds to base `Filter` library
   - Implements in `CRUD` helper
   - Adds to API/Swagger _only if_ `SupportFieldRedaction` is set
       - This is because FireFly Core is not using `CRUD` library and hence will not support this
- Convenience of having modifiers on the base `FilterBuilder` so you can do:
    ```go
    fb.And(conditions...).Limit(1).Sort("-created") // possible before: results in Filter
    fb.Limit(1).Sort("-created").And(conditions...) // now possible: results in AndFilter
    ```
