### PR TITLE
Add mods to fields, specifically for "lower(field)" in SQL

### DIFF
--- a/pkg/ffapi/filter_test.go
+++ b/pkg/ffapi/filter_test.go
@@ -180,6 +180,18 @@ func TestBuildMessageTimeConvert(t *testing.T) {
 	assert.Equal(t, "( created >> 1621112824000000000 ) && ( created >> 0 ) && ( created == 1621112874123456789 ) && ( created == null ) && ( created << 1621112824000000000 ) && ( created << 1621112824000000000 )", f.String())
 }
 
+func TestLowerField(t *testing.T) {
+	fb := TestQueryFactory.NewFilter(context.Background())
+	addr1 := "0xf698D78272a0bCD63A3feb097B24a866f6b8a5a0"
+	addr2 := "0xb9B919763dBC54D4D634150446Bf3991A9ef5eD7"
+	f, err := fb.And(
+		fb.Eq("address", addr1),
+		fb.In("address", []driver.Value{addr1, addr2}),
+	).Finalize()
+	assert.NoError(t, err)
+	assert.Equal(t, "( lower(address) == '0xf698D78272a0bCD63A3feb097B24a866f6b8a5a0' ) && ( lower(address) IN ['0xf698D78272a0bCD63A3feb097B24a866f6b8a5a0','0xb9B919763dBC54D4D634150446Bf3991A9ef5eD7'] )", f.String())
+}
+
 func TestBuildMessageStringConvert(t *testing.T) {
 	fb := TestQueryFactory.NewFilter(context.Background())
 	u := fftypes.MustParseUUID("3f96e0d5-a10e-47c6-87a0-f2e7604af179")

--- a/pkg/ffapi/query_fields.go
+++ b/pkg/ffapi/query_fields.go
@@ -39,6 +39,17 @@ type QueryFactory interface {
 	NewUpdate(ctx context.Context) UpdateBuilder
 }
 
+type FieldMod int
+
+const (
+	FieldModLower FieldMod = iota
+)
+
+// HasFieldMods can be set on a QueryField to do special things that a DB might support - like lowercase index filtering
+type HasFieldMods interface {
+	FieldMods() []FieldMod
+}
+
 type QueryFields map[string]Field
 
 func (qf *QueryFields) NewFilterLimit(ctx context.Context, defLimit uint64) FilterBuilder {
@@ -130,6 +141,13 @@ func (f *stringField) String() string                       { return f.s }
 func (f *StringField) GetSerialization() FieldSerialization { return &stringField{} }
 func (f *StringField) FilterAsString() bool                 { return true }
 func (f *StringField) Description() string                  { return "String" }
+
+type StringFieldLower struct {
+	StringField
+}
+
+func (f *StringFieldLower) GetSerialization() FieldSerialization { return &stringField{} }
+func (f *StringFieldLower) FieldMods() []FieldMod                { return []FieldMod{FieldModLower} }
 
 type UUIDField struct{}
 type uuidField struct{ u *fftypes.UUID }

--- a/pkg/ffapi/update_test.go
+++ b/pkg/ffapi/update_test.go
@@ -35,6 +35,7 @@ var TestQueryFactory = &QueryFields{
 	"tag":      &StringField{},
 	"topics":   &FFStringArrayField{},
 	"type":     &StringField{},
+	"address":  &StringFieldLower{},
 }
 
 func TestUpdateBuilderOK(t *testing.T) {


### PR DESCRIPTION
Have a microservice with a requirement to use `lower(address)` function on query filters against the DB, in order to work with a PostgreSQL index on `lower(address)`. This allows efficient indexed query, using case insensitive searches (for example using the checksumed Eth address).

With this PR, it should be as simple as:
https://github.com/hyperledger/firefly-common/blob/8c28b1d53192521a17931bed7dfd8c68de37d5c2/pkg/dbsql/filter_sql_test.go#L43