### PR TITLE
Add optional name/get-first semantics to CRUD

### DIFF
--- a/pkg/i18n/en_base_error_messages.go
+++ b/pkg/i18n/en_base_error_messages.go
@@ -146,4 +146,5 @@ var (
 	MsgInvalidTLSDnMismatch                        = ffe("FF00211", "Certificate subject does not meet requirements")
 	MsgDBUnknownGetOption                          = ffe("FF00212", "Unknown get option (%d)", 400)
 	MsgDBPatchNotSupportedForCollection            = ffe("FF00213", "Patch not supported for collection '%s'", 405)
+	MsgCollectionNotConfiguredWithName             = ffe("FF00214", "Name based queries not supported for collection '%s'", 405)
 )

--- a/test/dbmigrations/000001_create_crudables_table.up.sql
+++ b/test/dbmigrations/000001_create_crudables_table.up.sql
@@ -4,6 +4,7 @@ CREATE TABLE crudables (
   created     BIGINT          NOT NULL,
   updated     BIGINT          NOT NULL,
   ns          VARCHAR(64)     NOT NULL,
+  name        TEXT,
   field1      TEXT,
   field2      VARCHAR(65),
   field3      TEXT


### PR DESCRIPTION
It's common (including in FireFly core) to have:
- A special `name` column, that can be used in paths as an alternative to UUID
- To have IDs that must conform to a special syntax - especially UUIDs
- To want to do a get that returns zero/one entry for some filter combination that is not the ID

This PR provides those features as optional base functionality in `CRUD` to avoid the need to implement many times.