### PR TITLE
add option to specify variables in openapi base path

### DIFF
--- a/pkg/ffapi/openapi3_test.go
+++ b/pkg/ffapi/openapi3_test.go
@@ -368,3 +368,27 @@ func TestPreTranslatedRouteDescription(t *testing.T) {
 	description := swagger.Paths["/namespaces/{ns}/example1/test"].Post.Description
 	assert.Equal(t, "this is a description", description)
 }
+
+func TestBaseURLVariables(t *testing.T) {
+	doc := NewSwaggerGen(&Options{
+		Title:   "UnitTest",
+		Version: "1.0",
+		BaseURL: "http://localhost:12345/api/v1/{param}",
+		BaseURLVariables: map[string]BaseURLVariable{
+			"param": {
+				Default: "default-value",
+			},
+		},
+	}).Generate(context.Background(), testRoutes)
+	err := doc.Validate(context.Background())
+	assert.NoError(t, err)
+
+	server := doc.Servers[0]
+	if assert.Contains(t, server.Variables, "param") {
+		assert.Equal(t, "default-value", server.Variables["param"].Default)
+	}
+
+	b, err := yaml.Marshal(doc)
+	assert.NoError(t, err)
+	fmt.Print(string(b))
+}


### PR DESCRIPTION
Adds the option to specify base path variables to openapi generation.

E.g.
```yaml
servers:
  - url: http://example.com/{param}
    variables:
      param:
        default: default-value
```

Since the same route object can be used for swagger generation and route handling, I've also added the option to specify a base path and base path parameters to the handler factory so that path parameters can be parsed out of the request url without them needing to be specified in the route object (which would make them appear under the path in the openapi doc).