### PR TITLE
Improve mapping of errors on HTTP responses, and log stacks with debug

### DIFF
--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
+	"github.com/sirupsen/logrus"
 )
 
 const FFRequestIDHeader = "X-FireFly-Request-ID"
@@ -297,12 +298,19 @@ func (hs *HandlerFactory) APIWrapper(handler func(res http.ResponseWriter, req *
 		durationMS := float64(time.Since(startTime)) / float64(time.Millisecond)
 		if err != nil {
 
-			// Routers don't need to tweak the status code when sending errors.
-			// .. either the FF12345 error they raise is mapped to a status hint
-			ffMsgCodeExtract := ffMsgCodeExtractor.FindStringSubmatch(err.Error())
-			if len(ffMsgCodeExtract) >= 2 {
-				if statusHint, ok := i18n.GetStatusHint(ffMsgCodeExtract[1]); ok {
-					status = statusHint
+			if ffe, ok := (interface{}(err)).(i18n.FFError); ok {
+				if logrus.IsLevelEnabled(logrus.DebugLevel) {
+					log.L(ctx).Debugf("%s:\n%s", ffe.Error(), ffe.StackTrace())
+				}
+				status = ffe.HTTPStatus()
+			} else {
+				// Routers don't need to tweak the status code when sending errors.
+				// .. either the FF12345 error they raise is mapped to a status hint
+				ffMsgCodeExtract := ffMsgCodeExtractor.FindStringSubmatch(err.Error())
+				if len(ffMsgCodeExtract) >= 2 {
+					if statusHint, ok := i18n.GetStatusHint(ffMsgCodeExtract[1]); ok {
+						status = statusHint
+					}
 				}
 			}
 

--- a/pkg/ffapi/handler_test.go
+++ b/pkg/ffapi/handler_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/httpserver"
-	"github.com/hyperledger/firefly-common/pkg/i18n"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -184,7 +184,7 @@ func TestStatusCodeHintMapping(t *testing.T) {
 		JSONOutputValue: func() interface{} { return make(map[string]interface{}) },
 		JSONOutputCodes: []int{200},
 		JSONHandler: func(r *APIRequest) (output interface{}, err error) {
-			return nil, i18n.NewError(r.Req.Context(), i18n.MsgResponseMarshalError)
+			return nil, fmt.Errorf("FF00165: fake up this error to check we still catch the 400")
 		},
 	}})
 	defer done()
@@ -333,6 +333,9 @@ func TestMultipartBinary(t *testing.T) {
 }
 
 func TestMultipartBinaryFieldAfterBinary(t *testing.T) {
+	config.SetupLogging(context.Background())
+	logrus.SetLevel(logrus.DebugLevel) // so we can see the stack
+
 	s, _, done := newTestServer(t, []*Route{{
 		Name:   "testRoute",
 		Path:   "/test",

--- a/pkg/i18n/errors_test.go
+++ b/pkg/i18n/errors_test.go
@@ -33,14 +33,35 @@ func TestNewError(t *testing.T) {
 func TestNewErrorTruncate(t *testing.T) {
 	err := NewError(context.Background(), MsgUnknownFieldValue, "field", strings.Repeat("x", 3000))
 	assert.Error(t, err)
+	var ffe FFError
+	assert.Implements(t, &ffe, err)
+	assert.Equal(t, 400, interface{}(err).(FFError).HTTPStatus())
+	assert.Equal(t, MsgUnknownFieldValue, interface{}(err).(FFError).MessageKey())
 }
 
 func TestWrapError(t *testing.T) {
 	err := WrapError(context.Background(), fmt.Errorf("some error"), MsgConfigFailed)
 	assert.Error(t, err)
+	var ffe FFError
+	assert.Implements(t, &ffe, err)
+	assert.Equal(t, 500, interface{}(err).(FFError).HTTPStatus())
+	assert.Equal(t, MsgConfigFailed, interface{}(err).(FFError).MessageKey())
+	stackString := interface{}(err).(FFError).StackTrace()
+	fmt.Printf(stackString)
+	assert.NotEmpty(t, stackString)
+}
+
+func TestSafeStackFail(t *testing.T) {
+	stackString := (&ffError{}).StackTrace()
+	assert.Empty(t, stackString)
 }
 
 func TestWrapNilError(t *testing.T) {
+	err := WrapError(context.Background(), nil, MsgConfigFailed)
+	assert.Error(t, err)
+}
+
+func TestStackWithDebug(t *testing.T) {
 	err := WrapError(context.Background(), nil, MsgConfigFailed)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
The use of string parsing could be improved, especially as it doesn't work in cases where the `i18n` framework is used with custom non-`FF` prefixes (which we support).