### PR TITLE
Define richer "ColumnsExt" syntax for CRUD base

### DIFF
--- a/pkg/dbsql/crud_test.go
+++ b/pkg/dbsql/crud_test.go
@@ -1286,4 +1286,10 @@ func TestColumnsExt(t *testing.T) {
 	assert.Len(t, l1Copy, 1)
 	assert.Equal(t, "linked to C1", l1Copy[0].Description)
 	assert.Equal(t, "constant1", l1Copy[0].Field1)
+
+	l1Copy, _, err = linkables.GetMany(ctx, fb.Eq("field1", "constant1"))
+	assert.NoError(t, err)
+	assert.Len(t, l1Copy, 1)
+	assert.Equal(t, "linked to C1", l1Copy[0].Description)
+	assert.Equal(t, "constant1", l1Copy[0].Field1)
 }

--- a/pkg/dbsql/crud_test.go
+++ b/pkg/dbsql/crud_test.go
@@ -303,6 +303,7 @@ func newExtCollection(db *Database, ns string) *CrudBase[*TestLinkable] {
 			"field1": {
 				Select:        "'constant1'",
 				ReadOnly:      true,
+				OmitDefault:   true,
 				GetFieldPtr:   func(inst *TestLinkable) interface{} { return &inst.Field1 },
 				QueryModifier: func(sb sq.SelectBuilder) sq.SelectBuilder { return sb },
 			},
@@ -1275,6 +1276,12 @@ func TestColumnsExt(t *testing.T) {
 
 	fb := LinkableQueryFactory.NewFilter(ctx)
 	l1Copy, _, err := linkables.GetMany(ctx, fb.Eq("id", l1.ID))
+	assert.NoError(t, err)
+	assert.Len(t, l1Copy, 1)
+	assert.Equal(t, "linked to C1", l1Copy[0].Description)
+	assert.Empty(t, l1Copy[0].Field1)
+
+	l1Copy, _, err = linkables.GetMany(ctx, fb.Eq("id", l1.ID).ExtraFields("field1"))
 	assert.NoError(t, err)
 	assert.Len(t, l1Copy, 1)
 	assert.Equal(t, "linked to C1", l1Copy[0].Description)

--- a/pkg/dbsql/filter_sql.go
+++ b/pkg/dbsql/filter_sql.go
@@ -191,6 +191,15 @@ func (s *Database) FilterUpdate(ctx context.Context, update sq.UpdateBuilder, fi
 	return update.Where(fop), nil
 }
 
+func (s *Database) aliasColumn(tableName, fieldName string) string {
+	switch {
+	case tableName == "" || strings.Contains(fieldName, "."):
+		return fieldName
+	default:
+		return fmt.Sprintf("%s.%s", tableName, fieldName)
+	}
+}
+
 func (s *Database) mapFieldName(tableName, fieldName string, tm map[string]string) string {
 	if fieldName == "sequence" {
 		if tableName == "" {
@@ -204,10 +213,7 @@ func (s *Database) mapFieldName(tableName, fieldName string, tm map[string]strin
 			field = mf
 		}
 	}
-	if tableName != "" {
-		field = fmt.Sprintf("%s.%s", tableName, field)
-	}
-	return field
+	return s.aliasColumn(tableName, field)
 }
 
 func (s *Database) mapField(tableName string, op *ffapi.FilterInfo, tm map[string]string) string {

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -346,7 +346,7 @@ func (sg *SwaggerGen) addFilters(ctx context.Context, route *Route, op *openapi3
 		if sg.options.SupportFieldRedaction {
 			sg.AddParam(ctx, op, "query", "fields", "", "", i18n.APIFilterFieldsDesc, false)
 		}
-		sg.AddParam(ctx, op, "query", "extraFields", "", "", i18n.APIFilterExtraFieldsDesc, false)
+		sg.AddParam(ctx, op, "query", "extrafields", "", "", i18n.APIFilterExtraFieldsDesc, false)
 	}
 }
 

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -346,6 +346,7 @@ func (sg *SwaggerGen) addFilters(ctx context.Context, route *Route, op *openapi3
 		if sg.options.SupportFieldRedaction {
 			sg.AddParam(ctx, op, "query", "fields", "", "", i18n.APIFilterFieldsDesc, false)
 		}
+		sg.AddParam(ctx, op, "query", "extraFields", "", "", i18n.APIFilterExtraFieldsDesc, false)
 	}
 }
 

--- a/pkg/ffapi/restfilter.go
+++ b/pkg/ffapi/restfilter.go
@@ -133,7 +133,7 @@ func (hs *HandlerFactory) buildFilter(req *http.Request, ff QueryFactory) (AndFi
 			}
 		}
 	}
-	extraFieldVals := hs.getValues(req.Form, "extraFields")
+	extraFieldVals := hs.getValues(req.Form, "extrafields")
 	for _, ef := range extraFieldVals {
 		subExtraFieldVals := strings.Split(ef, ",")
 		for _, sef := range subExtraFieldVals {

--- a/pkg/ffapi/restfilter_test.go
+++ b/pkg/ffapi/restfilter_test.go
@@ -164,3 +164,17 @@ func TestBuildFilterRequiredFields(t *testing.T) {
 
 	assert.Equal(t, "( created == 0 ) requiredFields=tag,sequence", fi.String())
 }
+
+func TestBuildFilterExtraFields(t *testing.T) {
+	as := &HandlerFactory{
+		MaxFilterLimit: 250,
+	}
+
+	req := httptest.NewRequest("GET", "/things?created=0&extraFields=tag,sequence", nil)
+	filter, err := as.buildFilter(req, TestQueryFactory)
+	assert.NoError(t, err)
+	fi, err := filter.Finalize()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "( created == 0 ) extraFields=tag,sequence", fi.String())
+}

--- a/pkg/i18n/en_base_messages.go
+++ b/pkg/i18n/en_base_messages.go
@@ -25,16 +25,17 @@ var ffm = func(key, translation string) MessageKey {
 }
 
 var (
-	APISuccessResponse      = ffm("api.success", "Success")
-	APIRequestTimeoutDesc   = ffm("api.requestTimeout", "Server-side request timeout (milliseconds, or set a custom suffix like 10s)")
-	APIFilterParamDesc      = ffm("api.filterParam", "Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^")
-	APIFilterSortDesc       = ffm("api.filterSort", "Sort field. For multi-field sort use comma separated values (or multiple query values) with '-' prefix for descending")
-	APIFilterAscendingDesc  = ffm("api.filterAscending", "Ascending sort order (overrides all fields in a multi-field sort)")
-	APIFilterDescendingDesc = ffm("api.filterDescending", "Descending sort order (overrides all fields in a multi-field sort)")
-	APIFilterSkipDesc       = ffm("api.filterSkip", "The number of records to skip (max: %d). Unsuitable for bulk operations")
-	APIFilterLimitDesc      = ffm("api.filterLimit", "The maximum number of records to return (max: %d)")
-	APIFilterCountDesc      = ffm("api.filterCount", "Return a total count as well as items (adds extra database processing)")
-	APIFilterFieldsDesc     = ffm("api.filterFields", "Comma separated list of fields to return")
+	APISuccessResponse       = ffm("api.success", "Success")
+	APIRequestTimeoutDesc    = ffm("api.requestTimeout", "Server-side request timeout (milliseconds, or set a custom suffix like 10s)")
+	APIFilterParamDesc       = ffm("api.filterParam", "Data filter field. Prefixes supported: > >= < <= @ ^ ! !@ !^")
+	APIFilterSortDesc        = ffm("api.filterSort", "Sort field. For multi-field sort use comma separated values (or multiple query values) with '-' prefix for descending")
+	APIFilterAscendingDesc   = ffm("api.filterAscending", "Ascending sort order (overrides all fields in a multi-field sort)")
+	APIFilterDescendingDesc  = ffm("api.filterDescending", "Descending sort order (overrides all fields in a multi-field sort)")
+	APIFilterSkipDesc        = ffm("api.filterSkip", "The number of records to skip (max: %d). Unsuitable for bulk operations")
+	APIFilterLimitDesc       = ffm("api.filterLimit", "The maximum number of records to return (max: %d)")
+	APIFilterCountDesc       = ffm("api.filterCount", "Return a total count as well as items (adds extra database processing)")
+	APIFilterFieldsDesc      = ffm("api.filterFields", "Comma separated list of fields to return (replaces the default set of fields)")
+	APIFilterExtraFieldsDesc = ffm("api.filterExtraFields", "Comma separated list of extra fields to return (extends the default set of fields)")
 
 	ResourceBaseID      = ffm("ResourceBase.id", "The UUID of the service")
 	ResourceBaseCreated = ffm("ResourceBase.created", "The time the resource was created")


### PR DESCRIPTION
Rather than continuing to add per-column flags in a piecemeal fashion, define Columns as a map. The following concepts have been migrated from top-level CRUD configs to per-column settings (although the original ones will still be honored):
* read-only columns
* immutable columns
* query modifiers

**New column features**
Each column may override its `Select` query. This allows selecting complex fields which don't actually map to a single column in this table (such as foreign columns, sub-queries, or data processed by [Postgres functions](https://www.postgresql.org/docs/9.1/functions.html)).

Each column may specify `OmitDefault` in order to be excluded from queries by default. When querying via REST, such columns can be included by using the existing `fields=` syntax to choose all fields explicitly, or a new `extrafields=` syntax to receive a few extra fields along with all the default fields.