### PR TITLE
Add AsString helper function to JSONAny

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-  "go.formatFlags": [
-    "-s"
-  ],
+  "go.formatFlags": ["-s"],
   "go.lintTool": "golangci-lint",
   "cSpell.words": [
     "codecov",
@@ -31,6 +29,7 @@
     "passwordfile",
     "runtimes",
     "TLSCA",
+    "unmarshaling",
     "unserializable",
     "Upsert",
     "Warnf",

--- a/pkg/fftypes/jsonany.go
+++ b/pkg/fftypes/jsonany.go
@@ -47,6 +47,7 @@ func JSONAnyPtrBytes(b []byte) *JSONAny {
 	return &ja
 }
 
+// Unmarshals a byte array and sets h as a pointer to the result
 func (h *JSONAny) UnmarshalJSON(b []byte) error {
 	if len(b) == 0 {
 		*h = JSONAny(NullString)
@@ -86,12 +87,23 @@ func (h *JSONAny) Hash() *Bytes32 {
 	return &b32
 }
 
+// Returns the raw JSON as a string without unmarshaling
 func (h *JSONAny) String() string {
 	if h == nil {
 		return NullString
 	}
 	b, _ := h.MarshalJSON()
 	return string(b)
+}
+
+// Attempts to unmarshal the JSONAny as a string and return it
+func (h *JSONAny) AsString() string {
+	if h == nil {
+		return NullString
+	}
+	s := ""
+	_ = h.Unmarshal(context.Background(), &s)
+	return s
 }
 
 func (h *JSONAny) Length() int64 {

--- a/pkg/fftypes/jsonany_test.go
+++ b/pkg/fftypes/jsonany_test.go
@@ -184,3 +184,11 @@ func TestUnmarshal(t *testing.T) {
 func TestNilHash(t *testing.T) {
 	assert.Nil(t, (*JSONAny)(nil).Hash())
 }
+
+func TestASString(t *testing.T) {
+	j := JSONAnyPtr("\"foo\"")
+	assert.Equal(t, "foo", j.AsString())
+
+	nj := (*JSONAny)(nil)
+	assert.Equal(t, "null", nj.AsString())
+}


### PR DESCRIPTION
Previously if a JSONAny was actually a JSON String it was cumbersome to get it as a plain string. This helper function makes it easier everywhere we need to do that.