### PR TITLE
Add "ModifyQuery" to CRUD interface for arbitrary SQL processing

### DIFF
--- a/mocks/crudmocks/crud.go
+++ b/mocks/crudmocks/crud.go
@@ -309,6 +309,22 @@ func (_m *CRUD[T]) InsertMany(ctx context.Context, instances []T, allowPartialSu
 	return r0
 }
 
+// ModifyQuery provides a mock function with given fields: modifier
+func (_m *CRUD[T]) ModifyQuery(modifier func(squirrel.SelectBuilder) squirrel.SelectBuilder) dbsql.CRUDQuery[T] {
+	ret := _m.Called(modifier)
+
+	var r0 dbsql.CRUDQuery[T]
+	if rf, ok := ret.Get(0).(func(func(squirrel.SelectBuilder) squirrel.SelectBuilder) dbsql.CRUDQuery[T]); ok {
+		r0 = rf(modifier)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(dbsql.CRUDQuery[T])
+		}
+	}
+
+	return r0
+}
+
 // Replace provides a mock function with given fields: ctx, inst, hooks
 func (_m *CRUD[T]) Replace(ctx context.Context, inst T, hooks ...dbsql.PostCompletionHook) error {
 	_va := make([]interface{}, len(hooks))
@@ -331,15 +347,15 @@ func (_m *CRUD[T]) Replace(ctx context.Context, inst T, hooks ...dbsql.PostCompl
 }
 
 // Scoped provides a mock function with given fields: scope
-func (_m *CRUD[T]) Scoped(scope squirrel.Eq) *dbsql.CrudBase[T] {
+func (_m *CRUD[T]) Scoped(scope squirrel.Eq) dbsql.CRUD[T] {
 	ret := _m.Called(scope)
 
-	var r0 *dbsql.CrudBase[T]
-	if rf, ok := ret.Get(0).(func(squirrel.Eq) *dbsql.CrudBase[T]); ok {
+	var r0 dbsql.CRUD[T]
+	if rf, ok := ret.Get(0).(func(squirrel.Eq) dbsql.CRUD[T]); ok {
 		r0 = rf(scope)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dbsql.CrudBase[T])
+			r0 = ret.Get(0).(dbsql.CRUD[T])
 		}
 	}
 

--- a/pkg/dbsql/crud.go
+++ b/pkg/dbsql/crud.go
@@ -91,12 +91,7 @@ func (r *ResourceBase) SetUpdated(t *fftypes.FFTime) {
 	r.Updated = t
 }
 
-type CRUD[T Resource] interface {
-	Validate()
-	Upsert(ctx context.Context, inst T, optimization UpsertOptimization, hooks ...PostCompletionHook) (created bool, err error)
-	InsertMany(ctx context.Context, instances []T, allowPartialSuccess bool, hooks ...PostCompletionHook) (err error)
-	Insert(ctx context.Context, inst T, hooks ...PostCompletionHook) (err error)
-	Replace(ctx context.Context, inst T, hooks ...PostCompletionHook) (err error)
+type CRUDQuery[T Resource] interface {
 	GetByID(ctx context.Context, id string, getOpts ...GetOption) (inst T, err error)
 	GetByUUIDOrName(ctx context.Context, uuidOrName string, getOpts ...GetOption) (result T, err error)
 	GetByName(ctx context.Context, name string, getOpts ...GetOption) (instance T, err error)
@@ -104,12 +99,22 @@ type CRUD[T Resource] interface {
 	GetSequenceForID(ctx context.Context, id string) (seq int64, err error)
 	GetMany(ctx context.Context, filter ffapi.Filter) (instances []T, fr *ffapi.FilterResult, err error)
 	Count(ctx context.Context, filter ffapi.Filter) (count int64, err error)
+	ModifyQuery(modifier QueryModifier) CRUDQuery[T]
+}
+
+type CRUD[T Resource] interface {
+	CRUDQuery[T]
+	Validate()
+	Upsert(ctx context.Context, inst T, optimization UpsertOptimization, hooks ...PostCompletionHook) (created bool, err error)
+	InsertMany(ctx context.Context, instances []T, allowPartialSuccess bool, hooks ...PostCompletionHook) (err error)
+	Insert(ctx context.Context, inst T, hooks ...PostCompletionHook) (err error)
+	Replace(ctx context.Context, inst T, hooks ...PostCompletionHook) (err error)
 	Update(ctx context.Context, id string, update ffapi.Update, hooks ...PostCompletionHook) (err error)
 	UpdateSparse(ctx context.Context, sparseUpdate T, hooks ...PostCompletionHook) (err error)
 	UpdateMany(ctx context.Context, filter ffapi.Filter, update ffapi.Update, hooks ...PostCompletionHook) (err error)
 	Delete(ctx context.Context, id string, hooks ...PostCompletionHook) (err error)
 	DeleteMany(ctx context.Context, filter ffapi.Filter, hooks ...PostCompletionHook) (err error) // no events
-	Scoped(scope sq.Eq) *CrudBase[T]                                                              // allows dynamic scoping to a collection
+	Scoped(scope sq.Eq) CRUD[T]                                                                   // allows dynamic scoping to a collection
 }
 
 type CrudBase[T Resource] struct {
@@ -133,13 +138,28 @@ type CrudBase[T Resource] struct {
 	// Optional extensions
 	ReadTableAlias    string
 	ReadOnlyColumns   []string
-	ReadQueryModifier func(sq.SelectBuilder) sq.SelectBuilder
+	ReadQueryModifier QueryModifier
 }
 
-func (c *CrudBase[T]) Scoped(scope sq.Eq) *CrudBase[T] {
+func (c *CrudBase[T]) Scoped(scope sq.Eq) CRUD[T] {
 	cScoped := *c
 	cScoped.ScopedFilter = func() sq.Eq { return scope }
 	return &cScoped
+}
+
+func (c *CrudBase[T]) ModifyQuery(newModifier QueryModifier) CRUDQuery[T] {
+	cModified := *c
+	originalModifier := cModified.ReadQueryModifier
+	cModified.ReadQueryModifier = func(sb sq.SelectBuilder) sq.SelectBuilder {
+		if originalModifier != nil {
+			sb = originalModifier(sb)
+		}
+		if newModifier != nil {
+			sb = newModifier(sb)
+		}
+		return sb
+	}
+	return &cModified
 }
 
 func UUIDValidator(ctx context.Context, idStr string) error {
@@ -656,7 +676,7 @@ func (c *CrudBase[T]) getManyScoped(ctx context.Context, tableFrom string, fi *f
 		}
 		instances = append(instances, inst)
 	}
-	return instances, c.DB.QueryRes(ctx, c.Table, tx, fop, fi), err
+	return instances, c.DB.QueryRes(ctx, c.Table, tx, fop, c.ReadQueryModifier, fi), err
 }
 
 func (c *CrudBase[T]) Count(ctx context.Context, filter ffapi.Filter) (count int64, err error) {
@@ -675,7 +695,7 @@ func (c *CrudBase[T]) Count(ctx context.Context, filter ffapi.Filter) (count int
 			fop,
 		}
 	}
-	return c.DB.CountQuery(ctx, c.Table, nil, fop, "*")
+	return c.DB.CountQuery(ctx, c.Table, nil, fop, c.ReadQueryModifier, "*")
 }
 
 func (c *CrudBase[T]) Update(ctx context.Context, id string, update ffapi.Update, hooks ...PostCompletionHook) (err error) {

--- a/pkg/dbsql/crud_test.go
+++ b/pkg/dbsql/crud_test.go
@@ -381,6 +381,16 @@ func TestCRUDWithDBEnd2End(t *testing.T) {
 	assert.NoError(t, err)
 	checkEqualExceptTimes(t, *c1, *c1copy)
 
+	// Check we get it back with custom modifiers
+	collection.ReadQueryModifier = func(sb sq.SelectBuilder) sq.SelectBuilder {
+		return sb.Where(sq.Eq{"ns": "ns1"})
+	}
+	c1copy, err = iCrud.ModifyQuery(func(sb sq.SelectBuilder) sq.SelectBuilder {
+		return sb.Where(sq.Eq{"field1": "hello1"})
+	}).GetByName(ctx, *c1.Name)
+	assert.NoError(t, err)
+	checkEqualExceptTimes(t, *c1, *c1copy)
+
 	// Upsert the existing row optimized
 	c1copy.Field1 = strPtr("hello again - 1")
 	created, err := iCrud.Upsert(ctx, c1copy, UpsertOptimizationExisting)

--- a/pkg/dbsql/filter_sql.go
+++ b/pkg/dbsql/filter_sql.go
@@ -143,7 +143,9 @@ func (s *Database) filterSelectFinalized(ctx context.Context, tableName string, 
 		sort[i] = fmt.Sprintf("%s%s%s", s.mapFieldName(tableName, sf.Field, typeMap), direction, nulls)
 	}
 	sortString = strings.Join(sort, ", ")
-	sel = sel.OrderBy(sortString)
+	if sortString != "" {
+		sel = sel.OrderBy(sortString)
+	}
 	if fi.Skip > 0 {
 		sel = sel.Offset(fi.Skip)
 	}


### PR DESCRIPTION
While ReadQueryModifier allows CRUD models to have static additions (for joins or complex filtering), this will allow for more dynamic additions to any query.