### PR TITLE
[wsclient] Allow for Embedded Basic Auth in URLs

### DIFF
--- a/pkg/fswatcher/fswatcher_test.go
+++ b/pkg/fswatcher/fswatcher_test.go
@@ -35,10 +35,16 @@ func TestFileListenerE2E(t *testing.T) {
 
 	filePath := fmt.Sprintf(fmt.Sprintf("%s/test.yaml", tmpDir))
 
+	// Create the file
+	os.WriteFile(fmt.Sprintf("%s/test.yaml", tmpDir), []byte(`{"ut_conf": "one"}`), 0664)
+
+	// Read initial config
 	viper.SetConfigType("yaml")
 	viper.SetConfigFile(filePath)
+	viper.ReadInConfig()
+	assert.Equal(t, "one", viper.Get("ut_conf"))
 
-	// Start listener on empty dir
+	// Start listener on config file
 	fsListenerDone := make(chan struct{})
 	fsListenerFired := make(chan bool)
 	ctx, cancelCtx := context.WithCancel(context.Background())
@@ -50,11 +56,6 @@ func TestFileListenerE2E(t *testing.T) {
 		close(fsListenerDone)
 	})
 	assert.NoError(t, err)
-
-	// Create the file
-	os.WriteFile(fmt.Sprintf("%s/test.yaml", tmpDir), []byte(`{"ut_conf": "one"}`), 0664)
-	<-fsListenerFired
-	assert.Equal(t, "one", viper.Get("ut_conf"))
 
 	// Delete and rename in another file
 	os.Remove(fmt.Sprintf("%s/test.yaml", tmpDir))

--- a/pkg/wsclient/wsclient.go
+++ b/pkg/wsclient/wsclient.go
@@ -253,6 +253,11 @@ func buildWSUrl(ctx context.Context, config *WSConfig) (string, error) {
 	if u.Scheme == "https" {
 		u.Scheme = "wss"
 	}
+	if config.AuthUsername == "" && config.AuthPassword == "" && u.User != nil {
+		config.AuthUsername = u.User.Username()
+		config.AuthPassword, _ = u.User.Password()
+	}
+	u.User = nil
 	return u.String(), nil
 }
 

--- a/pkg/wsclient/wsclient_test.go
+++ b/pkg/wsclient/wsclient_test.go
@@ -264,6 +264,18 @@ func TestWSClientBadURL(t *testing.T) {
 	assert.Regexp(t, "FF00149", err)
 }
 
+func TestBasicAuthRemap(t *testing.T) {
+	wsConfig := generateConfig()
+	wsConfig.HTTPURL = "https://user:pass@test:12345"
+	wsConfig.WSKeyPath = "/websocket"
+
+	url, err := buildWSUrl(context.Background(), wsConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, "wss://test:12345/websocket", url)
+	assert.Equal(t, "user", wsConfig.AuthUsername)
+	assert.Equal(t, "pass", wsConfig.AuthPassword)
+}
+
 func TestHTTPToWSURLRemap(t *testing.T) {
 	wsConfig := generateConfig()
 	wsConfig.HTTPURL = "http://test:12345"


### PR DESCRIPTION
We observed when using the `wsclient` package that if a WS URL had basic auth embedded in it we'd get the following error:
```
Kaleido Block IndexerCopyright (C) 2023 Kaleido
Version:  (Build Date: 2023-11-16T19:49:14Z)

time="2023-11-20T20:14:29.999Z" level=info msg="[i] No TLS configuration provided`"
time="2023-11-20T20:14:29.999Z" level=debug msg="Created REST client to https://user:pass@acme.com"
time="2023-11-20T20:14:29.999Z" level=warning msg="WS wss://user:pass@acme.com connect attempt 1 failed [-1]: "
time="2023-11-20T20:14:29.999Z" level=fatal msg="[!] Failed to connect to blockchain : FF00148: Websocket connect failed: malformed ws or wss URL"
```

In some cases, applied configurations are more difficult to change than a binary version. This change proposes that the credentials in the URL be handled more gracefully, in that 1) the embedded credentials are always removed from the URL string, and that 2) if the config did not have auth credentials provided, the embedded credentials are extracted and used automatically.