### PR TITLE
Fix docs regression in parameter descriptions that changes swagger gen

### DIFF
--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -316,7 +316,7 @@ func (sg *SwaggerGen) addOutput(ctx context.Context, doc *openapi3.T, route *Rou
 }
 
 func (sg *SwaggerGen) AddParam(ctx context.Context, op *openapi3.Operation, in, name, def, example string, description i18n.MessageKey, deprecated bool, msgArgs ...interface{}) {
-	sg.addParamInternal(ctx, op, in, name, def, example, false, description, deprecated, msgArgs)
+	sg.addParamInternal(ctx, op, in, name, def, example, false, description, deprecated, msgArgs...)
 }
 
 func (sg *SwaggerGen) addParamInternal(ctx context.Context, op *openapi3.Operation, in, name, def, example string, isArray bool, description i18n.MessageKey, deprecated bool, msgArgs ...interface{}) {


### PR DESCRIPTION
We're incorrectly adding a `[0]` to these messages after #107:

```
description: 'The maximum number of records to return (max: [0])'
                                                            ^^^
```