### PR TITLE
Provide more flexibility on how EventStream specs are stored

### DIFF
--- a/pkg/eventstreams/config.go
+++ b/pkg/eventstreams/config.go
@@ -32,12 +32,12 @@ import (
 // Generics:
 // - CT is the Configuration Type - the custom extensions to the configuration schema
 // - DT is the Data Type - the payload type that will be delivered to the application
-type DispatcherFactory[CT any, DT any] interface {
-	Validate(ctx context.Context, conf *Config[CT, DT], spec *EventStreamSpec[CT], tlsConfigs map[string]*tls.Config, phase LifecyclePhase) error
-	NewDispatcher(ctx context.Context, conf *Config[CT, DT], spec *EventStreamSpec[CT]) Dispatcher[DT]
+type DispatcherFactory[CT EventStreamSpec, DT any] interface {
+	Validate(ctx context.Context, conf *Config[CT, DT], spec CT, tlsConfigs map[string]*tls.Config, phase LifecyclePhase) error
+	NewDispatcher(ctx context.Context, conf *Config[CT, DT], spec CT) Dispatcher[DT]
 }
 
-type Config[CT any, DT any] struct {
+type Config[CT EventStreamSpec, DT any] struct {
 	TLSConfigs        map[string]*fftls.Config `ffstruct:"EventStreamConfig" json:"tlsConfigs,omitempty"`
 	Retry             *retry.Retry             `ffstruct:"EventStreamConfig" json:"retry,omitempty"`
 	DisablePrivateIPs bool                     `ffstruct:"EventStreamConfig" json:"disabledPrivateIPs"`
@@ -135,7 +135,7 @@ func InitConfig(conf config.Section) {
 
 // Optional function to generate config directly from YAML configuration using the config package.
 // You can also generate the configuration programmatically
-func GenerateConfig[CT any, DT any](ctx context.Context) *Config[CT, DT] {
+func GenerateConfig[CT EventStreamSpec, DT any](ctx context.Context) *Config[CT, DT] {
 	httpDefaults, _ := ffresty.GenerateConfig(ctx, WebhookDefaultsConfig)
 	tlsConfigs := map[string]*fftls.Config{}
 	for i := 0; i < TLSConfigs.ArraySize(); i++ {

--- a/pkg/eventstreams/config_test.go
+++ b/pkg/eventstreams/config_test.go
@@ -34,7 +34,7 @@ func TestGenerateConfigTLS(t *testing.T) {
 	tls0.Set(ConfigTLSConfigName, "tls0")
 	tls0.SubSection("tls").Set(fftls.HTTPConfTLSCAFile, t.TempDir())
 
-	c := GenerateConfig[testESConfig, testData](context.Background())
+	c := GenerateConfig[*GenericEventStream, testData](context.Background())
 	assert.True(t, c.TLSConfigs["tls0"].Enabled)
 
 }

--- a/pkg/eventstreams/e2e_test.go
+++ b/pkg/eventstreams/e2e_test.go
@@ -245,7 +245,7 @@ func TestE2E_WebsocketDeliveryRestartReset(t *testing.T) {
 	assert.Equal(t, 2, ts.startCount)
 
 	// Reset it and check we get the reset
-	err = mgr.ResetStream(ctx, es1.GetID(), "first")
+	err = mgr.ResetStream(ctx, es1.GetID(), ptrTo("first"))
 	assert.NoError(t, err)
 	wsReceiveAck(ctx, t, wsc, func(batch *EventBatch[testData]) {})
 	assert.Equal(t, "first", ts.sequenceStartedWith)

--- a/pkg/eventstreams/e2e_test.go
+++ b/pkg/eventstreams/e2e_test.go
@@ -428,7 +428,7 @@ func TestE2E_CRUDLifecycle(t *testing.T) {
 	assert.True(t, created)
 
 	// Find the second one by topic filter
-	esList, _, err := mgr.ListStreams(ctx, EventStreamFilters.NewFilter(ctx).Eq("topicfilter", "topic2"))
+	esList, _, err := mgr.ListStreams(ctx, GenericEventStreamFilters.NewFilter(ctx).Eq("topicfilter", "topic2"))
 	assert.NoError(t, err)
 	assert.Len(t, esList, 1)
 	assert.Equal(t, "stream2", *esList[0].Name)
@@ -468,7 +468,7 @@ func TestE2E_CRUDLifecycle(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check no streams left
-	esList, _, err = mgr.ListStreams(ctx, EventStreamFilters.NewFilter(ctx).And())
+	esList, _, err = mgr.ListStreams(ctx, GenericEventStreamFilters.NewFilter(ctx).And())
 	assert.NoError(t, err)
 	assert.Empty(t, esList)
 

--- a/pkg/eventstreams/e2e_test.go
+++ b/pkg/eventstreams/e2e_test.go
@@ -18,7 +18,6 @@ package eventstreams
 
 import (
 	"context"
-	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -37,18 +36,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type testESConfig struct {
-	Config1 string `json:"config1"`
-}
-
-func (tc *testESConfig) Scan(src interface{}) error {
-	return fftypes.JSONScan(src, tc)
-}
-
-func (tc *testESConfig) Value() (driver.Value, error) {
-	return fftypes.JSONValue(tc)
-}
-
 type testData struct {
 	Field1 int `json:"field1"`
 }
@@ -59,14 +46,18 @@ type testSource struct {
 	sequenceStartedWith string
 }
 
-func (ts *testSource) Validate(ctx context.Context, config *testESConfig) error {
-	if config.Config1 == "" {
-		return fmt.Errorf("config1 missing")
+func (ts *testSource) Validate(ctx context.Context, conf *GenericEventStream) error {
+	if conf.Name != nil && *conf.Name == "validator_fail_instruction" {
+		return fmt.Errorf("validator_failed")
 	}
 	return nil
 }
 
-func (ts *testSource) Run(ctx context.Context, spec *EventStreamSpec[testESConfig], checkpointSequenceID string, deliver Deliver[testData]) error {
+func (ts *testSource) WithRuntimeStatus(spec *GenericEventStream, status EventStreamStatus, stats *EventStreamStatistics) *GenericEventStream {
+	return spec.WithRuntimeStatus(status, stats)
+}
+
+func (ts *testSource) Run(ctx context.Context, spec *GenericEventStream, checkpointSequenceID string, deliver Deliver[testData]) error {
 	msgNumber := 0
 	ts.startCount++
 	ts.sequenceStartedWith = checkpointSequenceID
@@ -113,15 +104,16 @@ func TestE2E_DeliveryWebSockets(t *testing.T) {
 	ts := &testSource{started: make(chan struct{})}
 	close(ts.started) // start delivery immediately - will block as no WS connected
 
-	mgr, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), p, wss, ts)
+	mgr, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), p, wss, ts)
 	assert.NoError(t, err)
 
 	// Create a stream to sub-select one topic
-	es1 := &EventStreamSpec[testESConfig]{
-		TopicFilter: ptrTo("topic_1"), // only one of the topics
-		Type:        &EventStreamTypeWebSocket,
-		BatchSize:   ptrTo(10),
-		Config:      &testESConfig{Config1: "1111"},
+	es1 := &GenericEventStream{
+		Type: &EventStreamTypeWebSocket,
+		EventStreamSpecFields: EventStreamSpecFields{
+			TopicFilter: ptrTo("topic_1"), // only one of the topics
+			BatchSize:   ptrTo(10),
+		},
 	}
 	created, err := mgr.UpsertStream(ctx, "stream1", es1)
 	assert.NoError(t, err)
@@ -161,15 +153,16 @@ func TestE2E_DeliveryWebSocketsNack(t *testing.T) {
 	ts := &testSource{started: make(chan struct{})}
 	close(ts.started) // start delivery immediately - will block as no WS connected
 
-	mgr, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), p, wss, ts)
+	mgr, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), p, wss, ts)
 	assert.NoError(t, err)
 
 	// Create a stream to sub-select one topic
-	es1 := &EventStreamSpec[testESConfig]{
-		TopicFilter: ptrTo("topic_1"), // only one of the topics
-		Type:        &EventStreamTypeWebSocket,
-		BatchSize:   ptrTo(10),
-		Config:      &testESConfig{Config1: "1111"},
+	es1 := &GenericEventStream{
+		Type: &EventStreamTypeWebSocket,
+		EventStreamSpecFields: EventStreamSpecFields{
+			TopicFilter: ptrTo("topic_1"), // only one of the topics
+			BatchSize:   ptrTo(10),
+		},
 	}
 	created, err := mgr.UpsertStream(ctx, "stream1", es1)
 	assert.NoError(t, err)
@@ -206,15 +199,16 @@ func TestE2E_WebsocketDeliveryRestartReset(t *testing.T) {
 	ts := &testSource{started: make(chan struct{})}
 	close(ts.started) // start delivery immediately - will block as no WS connected
 
-	mgr, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), p, wss, ts)
+	mgr, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), p, wss, ts)
 	assert.NoError(t, err)
 
 	// Create a stream to sub-select one topic
-	es1 := &EventStreamSpec[testESConfig]{
-		TopicFilter: ptrTo("topic_1"), // only one of the topics
-		Type:        &EventStreamTypeWebSocket,
-		BatchSize:   ptrTo(10),
-		Config:      &testESConfig{Config1: "1111"},
+	es1 := &GenericEventStream{
+		Type: &EventStreamTypeWebSocket,
+		EventStreamSpecFields: EventStreamSpecFields{
+			TopicFilter: ptrTo("topic_1"), // only one of the topics
+			BatchSize:   ptrTo(10),
+		},
 	}
 	created, err := mgr.UpsertStream(ctx, "stream1", es1)
 	assert.NoError(t, err)
@@ -232,7 +226,7 @@ func TestE2E_WebsocketDeliveryRestartReset(t *testing.T) {
 	assert.Equal(t, 1, ts.startCount)
 
 	// Wait for the checkpoint to be reflected in the status
-	var ess *EventStreamWithStatus[testESConfig]
+	var ess *GenericEventStream
 	for ess == nil || ess.Statistics == nil || ess.Statistics.Checkpoint == "" {
 		time.Sleep(1 * time.Millisecond)
 		ess, err = mgr.GetStreamByID(ctx, es1.GetID())
@@ -266,7 +260,7 @@ func TestE2E_DeliveryWebHooks200(t *testing.T) {
 	ts := &testSource{started: make(chan struct{})}
 	close(ts.started) // start delivery immediately - will block as no WS connected
 
-	mgr, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), p, wss, ts)
+	mgr, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), p, wss, ts)
 	assert.NoError(t, err)
 
 	got100 := make(chan struct{})
@@ -298,11 +292,12 @@ func TestE2E_DeliveryWebHooks200(t *testing.T) {
 	defer whServer.Close()
 
 	// Create a stream to sub-select one topic
-	es1 := &EventStreamSpec[testESConfig]{
-		TopicFilter: ptrTo("topic_1"), // only one of the topics
-		Type:        &EventStreamTypeWebhook,
-		BatchSize:   ptrTo(10),
-		Config:      &testESConfig{Config1: "1111"},
+	es1 := &GenericEventStream{
+		Type: &EventStreamTypeWebhook,
+		EventStreamSpecFields: EventStreamSpecFields{
+			TopicFilter: ptrTo("topic_1"), // only one of the topics
+			BatchSize:   ptrTo(10),
+		},
 		Webhook: &WebhookConfig{
 			URL:    ptrTo(whServer.URL + "/some/path"),
 			Method: ptrTo("PUT"),
@@ -336,7 +331,7 @@ func TestE2E_DeliveryWebHooks500Retry(t *testing.T) {
 	ts := &testSource{started: make(chan struct{})}
 	close(ts.started) // start delivery immediately - will block as no WS connected
 
-	mgr, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), p, wss, ts)
+	mgr, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), p, wss, ts)
 	assert.NoError(t, err)
 
 	gotFiveTimes := make(chan struct{})
@@ -367,11 +362,12 @@ func TestE2E_DeliveryWebHooks500Retry(t *testing.T) {
 	defer whServer.Close()
 
 	// Create a stream to sub-select one topic
-	es1 := &EventStreamSpec[testESConfig]{
-		TopicFilter: ptrTo("topic_1"), // only one of the topics
-		Type:        &EventStreamTypeWebhook,
-		BatchSize:   ptrTo(10),
-		Config:      &testESConfig{Config1: "1111"},
+	es1 := &GenericEventStream{
+		Type: &EventStreamTypeWebhook,
+		EventStreamSpecFields: EventStreamSpecFields{
+			TopicFilter: ptrTo("topic_1"), // only one of the topics
+			BatchSize:   ptrTo(10),
+		},
 		Webhook: &WebhookConfig{
 			URL:    ptrTo(whServer.URL + "/some/path"),
 			Method: ptrTo("PUT"),
@@ -405,15 +401,14 @@ func TestE2E_CRUDLifecycle(t *testing.T) {
 		started: make(chan struct{}), // we never start it
 	}
 
-	mgr, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), p, wss, ts)
+	mgr, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), p, wss, ts)
 	assert.NoError(t, err)
 
 	// Create first event stream started
-	es1 := &EventStreamSpec[testESConfig]{
-		TopicFilter: ptrTo("topic1"), // only one of the topics
-		Type:        &EventStreamTypeWebSocket,
-		Config: &testESConfig{
-			Config1: "confValue1",
+	es1 := &GenericEventStream{
+		Type: &EventStreamTypeWebSocket,
+		EventStreamSpecFields: EventStreamSpecFields{
+			TopicFilter: ptrTo("topic1"), // only one of the topics
 		},
 	}
 	created, err := mgr.UpsertStream(ctx, "stream1", es1)
@@ -421,12 +416,11 @@ func TestE2E_CRUDLifecycle(t *testing.T) {
 	assert.True(t, created)
 
 	// Create second event stream stopped
-	es2 := &EventStreamSpec[testESConfig]{
-		TopicFilter: ptrTo("topic2"), // only one of the topics
-		Type:        &EventStreamTypeWebSocket,
-		Status:      &EventStreamStatusStopped,
-		Config: &testESConfig{
-			Config1: "confValue2",
+	es2 := &GenericEventStream{
+		Type: &EventStreamTypeWebSocket,
+		EventStreamSpecFields: EventStreamSpecFields{
+			TopicFilter: ptrTo("topic2"), // only one of the topics
+			Status:      &EventStreamStatusStopped,
 		},
 	}
 	created, err = mgr.UpsertStream(ctx, "stream2", es2)
@@ -440,14 +434,13 @@ func TestE2E_CRUDLifecycle(t *testing.T) {
 	assert.Equal(t, "stream2", *esList[0].Name)
 	assert.Equal(t, "topic2", *esList[0].TopicFilter)
 	assert.Equal(t, 50, *esList[0].BatchSize) // picked up default when it was loaded
-	assert.Equal(t, "confValue2", esList[0].Config.Config1)
-	assert.Equal(t, EventStreamStatusStopped, esList[0].Status)
+	assert.Equal(t, EventStreamStatusStopped, *esList[0].Status)
 
 	// Get the first by ID
 	es1c, err := mgr.GetStreamByID(ctx, es1.GetID(), dbsql.FailIfNotFound)
 	assert.NoError(t, err)
 	assert.Equal(t, "stream1", *es1c.Name)
-	assert.Equal(t, EventStreamStatusStarted, es1c.Status)
+	assert.Equal(t, EventStreamStatusStarted, *es1c.Status)
 
 	// Rename second event stream
 	es2.Name = ptrTo("stream2a")
@@ -460,13 +453,13 @@ func TestE2E_CRUDLifecycle(t *testing.T) {
 	assert.NoError(t, err)
 	es2c, err := mgr.GetStreamByID(ctx, es2.GetID(), dbsql.FailIfNotFound)
 	assert.NoError(t, err)
-	assert.Equal(t, EventStreamStatusStarted, es2c.Status)
+	assert.Equal(t, EventStreamStatusStarted, *es2c.Status)
 	assert.Equal(t, "stream2a", *es2c.Name)
 	err = mgr.StopStream(ctx, es2.GetID())
 	assert.NoError(t, err)
 	es2c, err = mgr.GetStreamByID(ctx, es2.GetID(), dbsql.FailIfNotFound)
 	assert.NoError(t, err)
-	assert.Equal(t, EventStreamStatusStopped, es2c.Status)
+	assert.Equal(t, EventStreamStatusStopped, *es2c.Status)
 	err = mgr.DeleteStream(ctx, es2.GetID())
 	assert.NoError(t, err)
 
@@ -501,7 +494,7 @@ func wsReceiveNack(ctx context.Context, t *testing.T, wsc wsclient.WSClient, cb 
 	assert.NoError(t, err)
 }
 
-func setupE2ETest(t *testing.T, extraSetup ...func()) (context.Context, Persistence[testESConfig], wsserver.WebSocketChannels, wsclient.WSClient, func()) {
+func setupE2ETest(t *testing.T, extraSetup ...func()) (context.Context, Persistence[*GenericEventStream], wsserver.WebSocketChannels, wsclient.WSClient, func()) {
 	logrus.SetLevel(logrus.TraceLevel)
 
 	ctx := context.Background()
@@ -527,7 +520,7 @@ func setupE2ETest(t *testing.T, extraSetup ...func()) (context.Context, Persiste
 	db, err := dbsql.NewSQLiteProvider(ctx, dbConf)
 	assert.NoError(t, err)
 
-	p := NewEventStreamPersistence[testESConfig](db, dbsql.UUIDValidator)
+	p := NewGenericEventStreamPersistence(db, dbsql.UUIDValidator)
 	p.EventStreams().Validate()
 	p.Checkpoints().Validate()
 

--- a/pkg/eventstreams/eventstreams.go
+++ b/pkg/eventstreams/eventstreams.go
@@ -91,7 +91,7 @@ type EventStreamSpec interface {
 type EventStreamSpecFields struct {
 	Name              *string            `ffstruct:"eventstream" json:"name,omitempty"`
 	Status            *EventStreamStatus `ffstruct:"eventstream" json:"status,omitempty"`
-	InitialSequenceID *string            `ffstruct:"eventstream" json:"initialSequenceID,omitempty"`
+	InitialSequenceID *string            `ffstruct:"eventstream" json:"initialSequenceId,omitempty"`
 	TopicFilter       *string            `ffstruct:"eventstream" json:"topicFilter,omitempty"`
 
 	ErrorHandling     *ErrorHandlingType  `ffstruct:"eventstream" json:"errorHandling"`

--- a/pkg/eventstreams/eventstreams.go
+++ b/pkg/eventstreams/eventstreams.go
@@ -365,7 +365,7 @@ func (es *eventStream[CT, DT]) checkSetStatus(ctx context.Context, targetStatus 
 }
 
 func (es *eventStream[CT, DT]) persistStatus(ctx context.Context, targetStatus EventStreamStatus) error {
-	fb := EventStreamFilters.NewUpdate(ctx)
+	fb := GenericEventStreamFilters.NewUpdate(ctx)
 	return es.esm.persistence.EventStreams().Update(ctx, es.spec.GetID(), fb.Set("status", targetStatus))
 }
 

--- a/pkg/eventstreams/eventstreams.go
+++ b/pkg/eventstreams/eventstreams.go
@@ -93,7 +93,6 @@ type EventStreamSpecFields struct {
 	Status            *EventStreamStatus `ffstruct:"eventstream" json:"status,omitempty"`
 	InitialSequenceID *string            `ffstruct:"eventstream" json:"initialSequenceID,omitempty"`
 	TopicFilter       *string            `ffstruct:"eventstream" json:"topicFilter,omitempty"`
-	Identity          *string            `ffstruct:"eventstream" json:"identity,omitempty"`
 
 	ErrorHandling     *ErrorHandlingType  `ffstruct:"eventstream" json:"errorHandling"`
 	BatchSize         *int                `ffstruct:"eventstream" json:"batchSize"`

--- a/pkg/eventstreams/eventstreams_test.go
+++ b/pkg/eventstreams/eventstreams_test.go
@@ -33,7 +33,7 @@ func newTestEventStream(t *testing.T, extraSetup ...func(mdb *mockPersistence)) 
 		mdb.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil)
 	})
 	ctx, mgr, mes, done := newMockESManager(t, extraSetup...)
-	es, err := mgr.initEventStream(ctx, &GenericEventStream{
+	es, err := mgr.initEventStream(&GenericEventStream{
 		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
 		EventStreamSpecFields: EventStreamSpecFields{
 			Name:   ptrTo(t.Name()),
@@ -161,7 +161,7 @@ func TestValidate(t *testing.T) {
 	_, err = es.esm.validateStream(ctx, es.spec, LifecyclePhasePreInsertValidation)
 	assert.Regexp(t, "FF00216", err)
 
-	_, err = es.esm.initEventStream(ctx, es.spec)
+	_, err = es.esm.initEventStream(es.spec)
 	assert.Regexp(t, "FF00216", err)
 
 	customType := fftypes.FFEnumValue("estype", "custom1")
@@ -169,7 +169,7 @@ func TestValidate(t *testing.T) {
 	_, err = es.esm.validateStream(ctx, es.spec, LifecyclePhasePreInsertValidation)
 	assert.Regexp(t, "FF00217", err)
 
-	_, err = es.esm.initEventStream(ctx, es.spec)
+	_, err = es.esm.initEventStream(es.spec)
 	assert.Regexp(t, "FF00217", err)
 
 }

--- a/pkg/eventstreams/eventstreams_test.go
+++ b/pkg/eventstreams/eventstreams_test.go
@@ -21,21 +21,24 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hyperledger/firefly-common/pkg/dbsql"
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func newTestEventStream(t *testing.T, extraSetup ...func(mdb *mockPersistence)) (context.Context, *eventStream[testESConfig, testData], *mockEventSource, func()) {
+func newTestEventStream(t *testing.T, extraSetup ...func(mdb *mockPersistence)) (context.Context, *eventStream[*GenericEventStream, testData], *mockEventSource, func()) {
 	extraSetup = append(extraSetup, func(mdb *mockPersistence) {
-		mdb.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil)
+		mdb.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil)
 	})
 	ctx, mgr, mes, done := newMockESManager(t, extraSetup...)
-	es, err := mgr.initEventStream(ctx, &EventStreamSpec[testESConfig]{
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Name:   ptrTo(t.Name()),
-		Status: ptrTo(EventStreamStatusStopped),
+	es, err := mgr.initEventStream(ctx, &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo(t.Name()),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	})
 	assert.NoError(t, err)
 
@@ -44,8 +47,8 @@ func newTestEventStream(t *testing.T, extraSetup ...func(mdb *mockPersistence)) 
 
 func TestEventStreamFields(t *testing.T) {
 
-	es := &EventStreamSpec[testESConfig]{
-		ID: ptrTo(fftypes.NewUUID().String()),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
 	}
 	assert.Equal(t, es.GetID(), es.GetID())
 	t1 := fftypes.Now()
@@ -123,7 +126,7 @@ func TestValidate(t *testing.T) {
 	ctx, es, _, done := newTestEventStream(t)
 	done()
 
-	es.spec = &EventStreamSpec[testESConfig]{}
+	es.spec = &GenericEventStream{}
 	_, err := es.esm.validateStream(ctx, es.spec, LifecyclePhasePreInsertValidation)
 	assert.Regexp(t, "FF00112", err)
 
@@ -131,12 +134,12 @@ func TestValidate(t *testing.T) {
 	_, err = es.esm.validateStream(ctx, es.spec, LifecyclePhasePreInsertValidation)
 	assert.NoError(t, err)
 
-	es.esm.runtime.(*mockEventSource).validate = func(ctx context.Context, conf *testESConfig) error {
+	es.esm.runtime.(*mockEventSource).validate = func(ctx context.Context, conf *GenericEventStream) error {
 		return fmt.Errorf("pop")
 	}
 	_, err = es.esm.validateStream(ctx, es.spec, LifecyclePhasePreInsertValidation)
 	assert.Regexp(t, "pop", err)
-	es.esm.runtime.(*mockEventSource).validate = func(ctx context.Context, conf *testESConfig) error { return nil }
+	es.esm.runtime.(*mockEventSource).validate = func(ctx context.Context, conf *GenericEventStream) error { return nil }
 
 	es.spec.TopicFilter = ptrTo("((((!Bad Regexp[")
 	_, err = es.esm.validateStream(ctx, es.spec, LifecyclePhasePreInsertValidation)
@@ -175,7 +178,7 @@ func TestRequestStopAlreadyStopping(t *testing.T) {
 	ctx, es, _, done := newTestEventStream(t)
 	defer done()
 
-	es.activeState = &activeStream[testESConfig, testData]{}
+	es.activeState = &activeStream[*GenericEventStream, testData]{}
 	es.stopping = make(chan struct{})
 	s := es.requestStop(ctx)
 	close(s)
@@ -190,7 +193,7 @@ func TestRequestStopPersistFail(t *testing.T) {
 	defer done()
 
 	es.spec.Status = ptrTo(EventStreamStatusDeleted)
-	as := &activeStream[testESConfig, testData]{
+	as := &activeStream[*GenericEventStream, testData]{
 		eventLoopDone: make(chan struct{}),
 		batchLoopDone: make(chan struct{}),
 	}
@@ -291,7 +294,7 @@ func TestSuspendTimeout(t *testing.T) {
 	ctx, es, _, done := newTestEventStream(t)
 	done()
 
-	es.activeState = &activeStream[testESConfig, testData]{}
+	es.activeState = &activeStream[*GenericEventStream, testData]{}
 	es.stopping = make(chan struct{})
 	err := es.suspend(ctx)
 	assert.Regexp(t, "FF00229", err)
@@ -299,10 +302,10 @@ func TestSuspendTimeout(t *testing.T) {
 }
 
 func TestGetIDNil(t *testing.T) {
-	assert.Empty(t, (&EventStreamSpec[testESConfig]{}).GetID())
+	assert.Empty(t, (&GenericEventStream{}).GetID())
 	assert.Empty(t, (&EventStreamCheckpoint{}).GetID())
 }
 
 func TestCheckDocs(t *testing.T) {
-	ffapi.CheckObjectDocumented(&EventStreamWithStatus[struct{}]{})
+	ffapi.CheckObjectDocumented(&GenericEventStream{})
 }

--- a/pkg/eventstreams/manager.go
+++ b/pkg/eventstreams/manager.go
@@ -343,7 +343,7 @@ func (esm *esManager[CT, DT]) GetStreamByID(ctx context.Context, id string, opts
 
 func (esm *esManager[CT, DT]) GetStreamByNameOrID(ctx context.Context, nameOrID string, opts ...dbsql.GetOption) (es CT, err error) {
 	esSpec, err := esm.persistence.EventStreams().GetByUUIDOrName(ctx, nameOrID, opts...)
-	if err == nil {
+	if err == nil && !esSpec.IsNil() {
 		es = esm.enrichGetStream(ctx, esSpec)
 	}
 	return

--- a/pkg/eventstreams/manager.go
+++ b/pkg/eventstreams/manager.go
@@ -156,7 +156,7 @@ func (esm *esManager[CT, DT]) initialize(ctx context.Context) error {
 	const pageSize = 25
 	var skip uint64
 	for {
-		fb := EventStreamFilters.NewFilter(ctx)
+		fb := GenericEventStreamFilters.NewFilter(ctx)
 		streams, _, err := esm.persistence.EventStreams().GetMany(ctx, fb.And().Skip(skip).Limit(pageSize))
 		if err != nil {
 			return err

--- a/pkg/eventstreams/manager.go
+++ b/pkg/eventstreams/manager.go
@@ -135,7 +135,7 @@ func (esm *esManager[CT, DT]) getStream(id string) *eventStream[CT, DT] {
 }
 
 func (esm *esManager[CT, DT]) getStreamByNameOrID(ctx context.Context, nameOrID string) (*eventStream[CT, DT], error) {
-	stream, err := esm.GetStreamByNameOrID(ctx, nameOrID)
+	stream, err := esm.GetStreamByNameOrID(ctx, nameOrID, dbsql.FailIfNotFound)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eventstreams/manager.go
+++ b/pkg/eventstreams/manager.go
@@ -36,7 +36,7 @@ type Manager[CT EventStreamSpec] interface {
 	ListStreams(ctx context.Context, filter ffapi.Filter) ([]CT, *ffapi.FilterResult, error)
 	StopStream(ctx context.Context, nameOrID string) error
 	StartStream(ctx context.Context, nameOrID string) error
-	ResetStream(ctx context.Context, nameOrID string, sequenceID string, preStartCallbacks ...func(ctx context.Context, spec CT)) error
+	ResetStream(ctx context.Context, nameOrID string, sequenceID string, preStartCallbacks ...func(ctx context.Context, spec CT) error) error
 	DeleteStream(ctx context.Context, nameOrID string) error
 	Close(ctx context.Context)
 }
@@ -276,7 +276,7 @@ func (esm *esManager[CT, DT]) StopStream(ctx context.Context, nameOrID string) e
 	return es.stop(ctx)
 }
 
-func (esm *esManager[CT, DT]) ResetStream(ctx context.Context, nameOrID string, sequenceID string, preStartCallbacks ...func(ctx context.Context, spec CT)) error {
+func (esm *esManager[CT, DT]) ResetStream(ctx context.Context, nameOrID string, sequenceID string, preStartCallbacks ...func(ctx context.Context, spec CT) error) error {
 	es, err := esm.getStreamByNameOrID(ctx, nameOrID)
 	if err != nil {
 		return err
@@ -300,7 +300,9 @@ func (esm *esManager[CT, DT]) ResetStream(ctx context.Context, nameOrID string, 
 	}
 	// Plug point for logic that might need to do other custom reset logic before restart
 	for _, cb := range preStartCallbacks {
-		cb(ctx, es.spec)
+		if err := cb(ctx, es.spec); err != nil {
+			return err
+		}
 	}
 	// if the spec status is running, restart it
 	if *esSpec.Status == EventStreamStatusStarted {

--- a/pkg/eventstreams/manager_test.go
+++ b/pkg/eventstreams/manager_test.go
@@ -385,7 +385,7 @@ func TestResetStreamNotKnown(t *testing.T) {
 	})
 	defer done()
 
-	err := esm.ResetStream(ctx, fftypes.NewUUID().String(), "")
+	err := esm.ResetStream(ctx, fftypes.NewUUID().String(), nil)
 	assert.Regexp(t, "FF00164", err)
 
 }
@@ -496,7 +496,7 @@ func TestResetStreamStopFailTimeout(t *testing.T) {
 	existing.esm = esm
 
 	esm.addStream(ctx, existing)
-	err := esm.ResetStream(ctx, existing.spec.GetID(), "")
+	err := esm.ResetStream(ctx, existing.spec.GetID(), nil)
 	assert.Regexp(t, "FF00229", err)
 
 }
@@ -520,7 +520,7 @@ func TestResetStreamStopFailDeleteCheckpoint(t *testing.T) {
 	existing.esm = esm
 
 	esm.addStream(ctx, existing)
-	err := esm.ResetStream(ctx, existing.spec.GetID(), "")
+	err := esm.ResetStream(ctx, existing.spec.GetID(), nil)
 	assert.Regexp(t, "pop", err)
 
 }
@@ -545,7 +545,7 @@ func TestResetStreamStopFailUpdateSequence(t *testing.T) {
 	existing.esm = esm
 
 	esm.addStream(ctx, existing)
-	err := esm.ResetStream(ctx, existing.spec.GetID(), "12345")
+	err := esm.ResetStream(ctx, existing.spec.GetID(), ptrTo("12345"))
 	assert.Regexp(t, "pop", err)
 
 }
@@ -571,7 +571,7 @@ func TestResetStreamNoOp(t *testing.T) {
 
 	esm.addStream(ctx, existing)
 	called := false
-	err := esm.ResetStream(ctx, existing.spec.GetID(), "12345", func(_ context.Context, spec *GenericEventStream) error {
+	err := esm.ResetStream(ctx, existing.spec.GetID(), ptrTo("12345"), func(_ context.Context, spec *GenericEventStream) error {
 		called = true
 		assert.Equal(t, existing.spec, spec)
 		return nil
@@ -601,7 +601,7 @@ func TestResetStreamCallbackErr(t *testing.T) {
 	existing.esm = esm
 
 	esm.addStream(ctx, existing)
-	err := esm.ResetStream(ctx, existing.spec.GetID(), "12345", func(_ context.Context, spec *GenericEventStream) error {
+	err := esm.ResetStream(ctx, existing.spec.GetID(), ptrTo("12345"), func(_ context.Context, spec *GenericEventStream) error {
 		return fmt.Errorf("pop")
 	})
 	assert.Regexp(t, "pop", err)

--- a/pkg/eventstreams/manager_test.go
+++ b/pkg/eventstreams/manager_test.go
@@ -85,7 +85,7 @@ func newMockESManager(t *testing.T, extraSetup ...func(mp *mockPersistence)) (co
 		eventStreams: crudmocks.NewCRUD[*GenericEventStream](t),
 		checkpoints:  crudmocks.NewCRUD[*EventStreamCheckpoint](t),
 	}
-	mp.eventStreams.On("GetQueryFactory").Return(EventStreamFilters).Maybe()
+	mp.eventStreams.On("GetQueryFactory").Return(GenericEventStreamFilters).Maybe()
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	config.RootConfigReset()
@@ -615,7 +615,7 @@ func TestListStreamsFail(t *testing.T) {
 	})
 	defer done()
 
-	_, _, err := esm.ListStreams(ctx, EventStreamFilters.NewFilter(ctx).And())
+	_, _, err := esm.ListStreams(ctx, GenericEventStreamFilters.NewFilter(ctx).And())
 	assert.Regexp(t, "pop", err)
 
 }

--- a/pkg/eventstreams/manager_test.go
+++ b/pkg/eventstreams/manager_test.go
@@ -353,8 +353,8 @@ func TestUpsertReInitExistingFailInit(t *testing.T) {
 func TestDeleteStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{
-			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // does not exist
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(&GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // exists in DB, but does not exist in runtime state
 		}, nil).Once()
 	})
 	defer done()
@@ -367,7 +367,7 @@ func TestDeleteStreamNotKnown(t *testing.T) {
 func TestDeleteStreamNotFound(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return((*GenericEventStream)(nil), fmt.Errorf("not found")).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return((*GenericEventStream)(nil), fmt.Errorf("not found")).Once()
 	})
 	defer done()
 
@@ -379,8 +379,8 @@ func TestDeleteStreamNotFound(t *testing.T) {
 func TestResetStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{
-			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // does not exist
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(&GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // exists in DB, but does not exist in runtime state
 		}, nil).Once()
 	})
 	defer done()
@@ -393,8 +393,8 @@ func TestResetStreamNotKnown(t *testing.T) {
 func TestStopStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{
-			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // does not exist
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(&GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // exists in DB, but does not exist in runtime state
 		}, nil).Once()
 	})
 	defer done()
@@ -407,8 +407,8 @@ func TestStopStreamNotKnown(t *testing.T) {
 func TestStartStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{
-			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // does not exist
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(&GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // exists in DB, but does not exist in runtime state
 		}, nil).Once()
 	})
 	defer done()
@@ -441,7 +441,7 @@ func TestDeleteStreamFail(t *testing.T) {
 		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(es, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(es, nil).Once()
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop")).Once()
@@ -462,7 +462,7 @@ func TestDeleteStreamFailDelete(t *testing.T) {
 		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(es, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(es, nil).Once()
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
@@ -489,7 +489,7 @@ func TestResetStreamStopFailTimeout(t *testing.T) {
 	}
 
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(existing.spec, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(existing.spec, nil).Once()
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	done()
@@ -512,7 +512,7 @@ func TestResetStreamStopFailDeleteCheckpoint(t *testing.T) {
 		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(existing.spec, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(existing.spec, nil).Once()
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.checkpoints.On("DeleteMany", mock.Anything, mock.Anything).Return(fmt.Errorf("pop")).Once()
 	})
@@ -536,7 +536,7 @@ func TestResetStreamStopFailUpdateSequence(t *testing.T) {
 		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(existing.spec, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(existing.spec, nil).Once()
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.checkpoints.On("DeleteMany", mock.Anything, mock.Anything).Return(nil).Once()
 		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop")).Once()
@@ -561,7 +561,7 @@ func TestResetStreamNoOp(t *testing.T) {
 		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(existing.spec, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(existing.spec, nil).Once()
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.checkpoints.On("DeleteMany", mock.Anything, mock.Anything).Return(nil).Once()
 		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
@@ -602,11 +602,11 @@ func TestGetStreamByIDFail(t *testing.T) {
 func TestGetStreamByNameOrID(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{}, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything, dbsql.FailIfNotFound).Return(&GenericEventStream{}, nil).Once()
 	})
 	defer done()
 
-	_, err := esm.GetStreamByNameOrID(ctx, "stream1")
+	_, err := esm.GetStreamByNameOrID(ctx, "stream1", dbsql.FailIfNotFound)
 	assert.NoError(t, err)
 
 }

--- a/pkg/eventstreams/manager_test.go
+++ b/pkg/eventstreams/manager_test.go
@@ -34,20 +34,24 @@ import (
 )
 
 type mockEventSource struct {
-	validate func(ctx context.Context, conf *testESConfig) error
-	run      func(ctx context.Context, es *EventStreamSpec[testESConfig], checkpointSequenceId string, deliver Deliver[testData]) error
+	validate func(ctx context.Context, conf *GenericEventStream) error
+	run      func(ctx context.Context, es *GenericEventStream, checkpointSequenceId string, deliver Deliver[testData]) error
 }
 
 func (mes *mockEventSource) NewID() string {
 	return fftypes.NewUUID().String()
 }
 
-func (mes *mockEventSource) Run(ctx context.Context, es *EventStreamSpec[testESConfig], checkpointSequenceId string, deliver Deliver[testData]) error {
+func (mes *mockEventSource) Run(ctx context.Context, es *GenericEventStream, checkpointSequenceId string, deliver Deliver[testData]) error {
 	return mes.run(ctx, es, checkpointSequenceId, deliver)
 }
 
-func (mes *mockEventSource) Validate(ctx context.Context, conf *testESConfig) error {
+func (mes *mockEventSource) Validate(ctx context.Context, conf *GenericEventStream) error {
 	return mes.validate(ctx, conf)
+}
+
+func (mes *mockEventSource) WithRuntimeStatus(spec *GenericEventStream, status EventStreamStatus, stats *EventStreamStatistics) *GenericEventStream {
+	return spec.WithRuntimeStatus(status, stats)
 }
 
 type mockAction struct {
@@ -59,11 +63,11 @@ func (ma *mockAction) AttemptDispatch(ctx context.Context, attempt int, events *
 }
 
 type mockPersistence struct {
-	eventStreams *crudmocks.CRUD[*EventStreamSpec[testESConfig]]
+	eventStreams *crudmocks.CRUD[*GenericEventStream]
 	checkpoints  *crudmocks.CRUD[*EventStreamCheckpoint]
 }
 
-func (mp *mockPersistence) EventStreams() dbsql.CRUD[*EventStreamSpec[testESConfig]] {
+func (mp *mockPersistence) EventStreams() dbsql.CRUD[*GenericEventStream] {
 	return mp.eventStreams
 }
 func (mp *mockPersistence) Checkpoints() dbsql.CRUD[*EventStreamCheckpoint] {
@@ -74,13 +78,14 @@ func (mp *mockPersistence) IDValidator() IDValidator {
 }
 func (mp *mockPersistence) Close() {}
 
-func newMockESManager(t *testing.T, extraSetup ...func(mp *mockPersistence)) (context.Context, *esManager[testESConfig, testData], *mockEventSource, func()) {
+func newMockESManager(t *testing.T, extraSetup ...func(mp *mockPersistence)) (context.Context, *esManager[*GenericEventStream, testData], *mockEventSource, func()) {
 	logrus.SetLevel(logrus.DebugLevel)
 
 	mp := &mockPersistence{
-		eventStreams: crudmocks.NewCRUD[*EventStreamSpec[testESConfig]](t),
+		eventStreams: crudmocks.NewCRUD[*GenericEventStream](t),
 		checkpoints:  crudmocks.NewCRUD[*EventStreamCheckpoint](t),
 	}
+	mp.eventStreams.On("GetQueryFactory").Return(EventStreamFilters).Maybe()
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	config.RootConfigReset()
@@ -96,23 +101,23 @@ func newMockESManager(t *testing.T, extraSetup ...func(mp *mockPersistence)) (co
 	}
 
 	mes := &mockEventSource{
-		validate: func(ctx context.Context, conf *testESConfig) error { return nil },
-		run: func(ctx context.Context, es *EventStreamSpec[testESConfig], checkpointSequenceId string, deliver Deliver[testData]) error {
+		validate: func(ctx context.Context, conf *GenericEventStream) error { return nil },
+		run: func(ctx context.Context, es *GenericEventStream, checkpointSequenceId string, deliver Deliver[testData]) error {
 			<-ctx.Done()
 			return nil
 		},
 	}
-	mgr, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), mp, nil, mes)
+	mgr, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), mp, nil, mes)
 	assert.NoError(t, err)
 
-	return ctx, mgr.(*esManager[testESConfig, testData]), mes, func() {
+	return ctx, mgr.(*esManager[*GenericEventStream, testData]), mes, func() {
 		mgr.Close(ctx)
 		cancelCtx()
 	}
 }
 
 func TestNewManagerFailBadTLS(t *testing.T) {
-	_, err := NewEventStreamManager[testESConfig, testData](context.Background(), &Config[testESConfig, testData]{
+	_, err := NewEventStreamManager[*GenericEventStream, testData](context.Background(), &Config[*GenericEventStream, testData]{
 		Retry: &retry.Retry{},
 		TLSConfigs: map[string]*fftls.Config{
 			"tls0": {
@@ -125,46 +130,34 @@ func TestNewManagerFailBadTLS(t *testing.T) {
 
 }
 
-func TestNewManagerBadConfStruct(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = NewEventStreamManager[string /* must be DBSerializable */, testData](context.Background(), &Config[string, testData]{
-			Retry: &retry.Retry{},
-			TLSConfigs: map[string]*fftls.Config{
-				"tls0": {
-					Enabled: true,
-					CAFile:  t.TempDir(),
-				},
-			},
-		}, nil, nil, nil)
-	})
-}
-
 func TestNewManagerBadConfState(t *testing.T) {
-	_, err := NewEventStreamManager[testESConfig, testData](context.Background(), &Config[testESConfig, testData]{}, nil, nil, &mockEventSource{})
+	_, err := NewEventStreamManager[*GenericEventStream, testData](context.Background(), &Config[*GenericEventStream, testData]{}, nil, nil, &mockEventSource{})
 	assert.Regexp(t, "FF00237", err)
 }
 
 func TestInitFail(t *testing.T) {
 	mp := &mockPersistence{
-		eventStreams: crudmocks.NewCRUD[*EventStreamSpec[testESConfig]](t),
+		eventStreams: crudmocks.NewCRUD[*GenericEventStream](t),
 		checkpoints:  crudmocks.NewCRUD[*EventStreamCheckpoint](t),
 	}
-	mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, fmt.Errorf("pop"))
+	mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, fmt.Errorf("pop"))
 	ctx := context.Background()
 	InitConfig(config.RootSection("ut"))
-	_, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), mp, nil, nil)
+	_, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), mp, nil, nil)
 	assert.Regexp(t, "pop", err)
 }
 
 func TestInitWithStreams(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Name:   ptrTo("stream1"),
-		Status: ptrTo(EventStreamStatusStarted),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStarted),
+		},
 	}
 	_, _, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.checkpoints.On("GetByID", mock.Anything, es.GetID()).Return((*EventStreamCheckpoint)(nil), nil)
 	})
 	defer done()
@@ -173,37 +166,41 @@ func TestInitWithStreams(t *testing.T) {
 
 func TestInitWithStreamsCleanupFail(t *testing.T) {
 	mp := &mockPersistence{
-		eventStreams: crudmocks.NewCRUD[*EventStreamSpec[testESConfig]](t),
+		eventStreams: crudmocks.NewCRUD[*GenericEventStream](t),
 		checkpoints:  crudmocks.NewCRUD[*EventStreamCheckpoint](t),
 	}
 	ctx := context.Background()
 	InitConfig(config.RootSection("ut"))
-	es := &EventStreamSpec[testESConfig]{
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Name:   ptrTo("stream1"),
-		Status: ptrTo(EventStreamStatusDeleted),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusDeleted),
+		},
 	}
-	mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
+	mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
 	mp.eventStreams.On("Delete", mock.Anything, es.GetID()).Return(fmt.Errorf("pop"))
-	_, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), mp, nil, nil)
+	_, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), mp, nil, nil)
 	assert.Regexp(t, "pop", err)
 }
 
 func TestInitWithStreamsInitFail(t *testing.T) {
 	mp := &mockPersistence{
-		eventStreams: crudmocks.NewCRUD[*EventStreamSpec[testESConfig]](t),
+		eventStreams: crudmocks.NewCRUD[*GenericEventStream](t),
 		checkpoints:  crudmocks.NewCRUD[*EventStreamCheckpoint](t),
 	}
 	ctx := context.Background()
 	InitConfig(config.RootSection("ut"))
-	es := &EventStreamSpec[testESConfig]{
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Name:   ptrTo("stream1"),
-		Status: ptrTo(EventStreamStatusStarted),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStarted),
+		},
 	}
-	mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-	_, err := NewEventStreamManager[testESConfig, testData](ctx, GenerateConfig[testESConfig, testData](ctx), mp, nil, &mockEventSource{
-		validate: func(ctx context.Context, conf *testESConfig) error {
+	mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+	_, err := NewEventStreamManager[*GenericEventStream, testData](ctx, GenerateConfig[*GenericEventStream, testData](ctx), mp, nil, &mockEventSource{
+		validate: func(ctx context.Context, conf *GenericEventStream) error {
 			return fmt.Errorf("pop")
 		},
 	})
@@ -211,15 +208,17 @@ func TestInitWithStreamsInitFail(t *testing.T) {
 }
 
 func TestUpsertStreamByNameDeleted(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		Name:   ptrTo("stream1"),
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Status: ptrTo(EventStreamStatusStopped),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetByName", mock.Anything, "stream1").Return(es, nil)
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	defer done()
 
@@ -230,15 +229,17 @@ func TestUpsertStreamByNameDeleted(t *testing.T) {
 }
 
 func TestUpsertStreamByNameFailLookup(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		Name:   ptrTo("stream1"),
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Status: ptrTo(EventStreamStatusStopped),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetByName", mock.Anything, "stream1").Return((*EventStreamSpec[testESConfig])(nil), fmt.Errorf("pop"))
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetByName", mock.Anything, "stream1").Return((*GenericEventStream)(nil), fmt.Errorf("pop"))
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	defer done()
 
@@ -249,32 +250,36 @@ func TestUpsertStreamByNameFailLookup(t *testing.T) {
 }
 
 func TestUpsertStreamByIDDeleted(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		Name:   ptrTo("stream1"),
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Status: ptrTo(EventStreamStatusStopped),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	defer done()
 
 	esm.getStream(es.GetID()).spec.Status = ptrTo(EventStreamStatusDeleted)
-	_, err := esm.UpsertStream(ctx, *es.ID, es)
+	_, err := esm.UpsertStream(ctx, es.GetID(), es)
 	assert.Regexp(t, "FF00236", err)
 
 }
 
 func TestUpsertStreamBadUpdate(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		Name:   ptrTo("stream1"),
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Status: ptrTo(EventStreamStatusStopped),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	defer done()
 
@@ -286,14 +291,16 @@ func TestUpsertStreamBadUpdate(t *testing.T) {
 }
 
 func TestUpsertStreamUpsertFail(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		Name:   ptrTo("stream1"),
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Status: ptrTo(EventStreamStatusStopped),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.eventStreams.On("Upsert", mock.Anything, mock.Anything, dbsql.UpsertOptimizationExisting).Return(false, fmt.Errorf("pop")).Once()
 	})
 	defer done()
@@ -304,18 +311,20 @@ func TestUpsertStreamUpsertFail(t *testing.T) {
 }
 
 func TestUpsertReInitExistingFailTimeout(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Name:   ptrTo("stream1"),
-		Status: ptrTo(EventStreamStatusStopped),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	done()
 
-	existing := &eventStream[testESConfig, testData]{
-		activeState: &activeStream[testESConfig, testData]{},
+	existing := &eventStream[*GenericEventStream, testData]{
+		activeState: &activeStream[*GenericEventStream, testData]{},
 		stopping:    make(chan struct{}),
 	}
 	err := esm.reInit(ctx, es, existing)
@@ -324,13 +333,15 @@ func TestUpsertReInitExistingFailTimeout(t *testing.T) {
 }
 
 func TestUpsertReInitExistingFailInit(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Name:   ptrTo("stream1"),
-		Status: ptrTo(fftypes.FFEnum("wrong")),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(fftypes.FFEnum("wrong")),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	done()
 
@@ -341,9 +352,9 @@ func TestUpsertReInitExistingFailInit(t *testing.T) {
 
 func TestDeleteStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&EventStreamSpec[testESConfig]{
-			ID: ptrTo("does not exist"),
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // does not exist
 		}, nil).Once()
 	})
 	defer done()
@@ -355,8 +366,8 @@ func TestDeleteStreamNotKnown(t *testing.T) {
 
 func TestDeleteStreamNotFound(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return((*EventStreamSpec[testESConfig])(nil), fmt.Errorf("not found")).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return((*GenericEventStream)(nil), fmt.Errorf("not found")).Once()
 	})
 	defer done()
 
@@ -367,9 +378,9 @@ func TestDeleteStreamNotFound(t *testing.T) {
 
 func TestResetStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&EventStreamSpec[testESConfig]{
-			ID: ptrTo("does not exist"),
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // does not exist
 		}, nil).Once()
 	})
 	defer done()
@@ -381,9 +392,9 @@ func TestResetStreamNotKnown(t *testing.T) {
 
 func TestStopStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&EventStreamSpec[testESConfig]{
-			ID: ptrTo("does not exist"),
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // does not exist
 		}, nil).Once()
 	})
 	defer done()
@@ -395,9 +406,9 @@ func TestStopStreamNotKnown(t *testing.T) {
 
 func TestStartStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&EventStreamSpec[testESConfig]{
-			ID: ptrTo("does not exist"),
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()}, // does not exist
 		}, nil).Once()
 	})
 	defer done()
@@ -409,28 +420,30 @@ func TestStartStreamNotKnown(t *testing.T) {
 
 func TestEnrichStreamNotKnown(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	defer done()
 
-	es := esm.enrichGetStream(ctx, &EventStreamSpec[testESConfig]{
-		ID: ptrTo(fftypes.NewUUID().String()),
+	es := esm.enrichGetStream(ctx, &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
 	})
 	assert.NotNil(t, es)
-	assert.Equal(t, EventStreamStatusUnknown, es.Status)
+	assert.Equal(t, EventStreamStatusUnknown, *es.Status)
 
 }
 
 func TestDeleteStreamFail(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Name:   ptrTo("stream1"),
-		Status: ptrTo(EventStreamStatusStopped),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(es, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop")).Once()
 	})
 	defer done()
@@ -441,15 +454,17 @@ func TestDeleteStreamFail(t *testing.T) {
 }
 
 func TestDeleteStreamFailDelete(t *testing.T) {
-	es := &EventStreamSpec[testESConfig]{
-		ID:     ptrTo(fftypes.NewUUID().String()),
-		Name:   ptrTo("stream1"),
-		Status: ptrTo(EventStreamStatusStopped),
+	es := &GenericEventStream{
+		ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name:   ptrTo("stream1"),
+			Status: ptrTo(EventStreamStatusStopped),
+		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(es, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 		mp.eventStreams.On("Delete", mock.Anything, mock.Anything).Return(fmt.Errorf("pop")).Once()
 	})
@@ -461,21 +476,24 @@ func TestDeleteStreamFailDelete(t *testing.T) {
 }
 
 func TestResetStreamStopFailTimeout(t *testing.T) {
-	existing := &eventStream[testESConfig, testData]{
-		activeState: &activeStream[testESConfig, testData]{},
+	existing := &eventStream[*GenericEventStream, testData]{
+		activeState: &activeStream[*GenericEventStream, testData]{},
 		stopping:    make(chan struct{}),
-		spec: &EventStreamSpec[testESConfig]{
-			ID:     ptrTo(fftypes.NewUUID().String()),
-			Name:   ptrTo("stream1"),
-			Status: ptrTo(EventStreamStatusStopped),
+		spec: &GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+			EventStreamSpecFields: EventStreamSpecFields{
+				Name:   ptrTo("stream1"),
+				Status: ptrTo(EventStreamStatusStopped),
+			},
 		},
 	}
 
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(existing.spec, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	done()
+	existing.esm = esm
 
 	esm.addStream(ctx, existing)
 	err := esm.ResetStream(ctx, existing.spec.GetID(), "")
@@ -484,19 +502,22 @@ func TestResetStreamStopFailTimeout(t *testing.T) {
 }
 
 func TestResetStreamStopFailDeleteCheckpoint(t *testing.T) {
-	existing := &eventStream[testESConfig, testData]{
-		spec: &EventStreamSpec[testESConfig]{
-			ID:     ptrTo(fftypes.NewUUID().String()),
-			Name:   ptrTo("stream1"),
-			Status: ptrTo(EventStreamStatusStopped),
+	existing := &eventStream[*GenericEventStream, testData]{
+		spec: &GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+			EventStreamSpecFields: EventStreamSpecFields{
+				Name:   ptrTo("stream1"),
+				Status: ptrTo(EventStreamStatusStopped),
+			},
 		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(existing.spec, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.checkpoints.On("DeleteMany", mock.Anything, mock.Anything).Return(fmt.Errorf("pop")).Once()
 	})
 	done()
+	existing.esm = esm
 
 	esm.addStream(ctx, existing)
 	err := esm.ResetStream(ctx, existing.spec.GetID(), "")
@@ -505,20 +526,23 @@ func TestResetStreamStopFailDeleteCheckpoint(t *testing.T) {
 }
 
 func TestResetStreamStopFailUpdateSequence(t *testing.T) {
-	existing := &eventStream[testESConfig, testData]{
-		spec: &EventStreamSpec[testESConfig]{
-			ID:     ptrTo(fftypes.NewUUID().String()),
-			Name:   ptrTo("stream1"),
-			Status: ptrTo(EventStreamStatusStopped),
+	existing := &eventStream[*GenericEventStream, testData]{
+		spec: &GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+			EventStreamSpecFields: EventStreamSpecFields{
+				Name:   ptrTo("stream1"),
+				Status: ptrTo(EventStreamStatusStopped),
+			},
 		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(existing.spec, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.checkpoints.On("DeleteMany", mock.Anything, mock.Anything).Return(nil).Once()
-		mp.eventStreams.On("UpdateSparse", mock.Anything, mock.Anything).Return(fmt.Errorf("pop")).Once()
+		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop")).Once()
 	})
 	done()
+	existing.esm = esm
 
 	esm.addStream(ctx, existing)
 	err := esm.ResetStream(ctx, existing.spec.GetID(), "12345")
@@ -527,20 +551,23 @@ func TestResetStreamStopFailUpdateSequence(t *testing.T) {
 }
 
 func TestResetStreamNoOp(t *testing.T) {
-	existing := &eventStream[testESConfig, testData]{
-		spec: &EventStreamSpec[testESConfig]{
-			ID:     ptrTo(fftypes.NewUUID().String()),
-			Name:   ptrTo("stream1"),
-			Status: ptrTo(EventStreamStatusStopped),
+	existing := &eventStream[*GenericEventStream, testData]{
+		spec: &GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+			EventStreamSpecFields: EventStreamSpecFields{
+				Name:   ptrTo("stream1"),
+				Status: ptrTo(EventStreamStatusStopped),
+			},
 		},
 	}
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
 		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(existing.spec, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 		mp.checkpoints.On("DeleteMany", mock.Anything, mock.Anything).Return(nil).Once()
-		mp.eventStreams.On("UpdateSparse", mock.Anything, mock.Anything).Return(nil).Once()
+		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	})
 	done()
+	existing.esm = esm
 
 	esm.addStream(ctx, existing)
 	err := esm.ResetStream(ctx, existing.spec.GetID(), "12345")
@@ -550,8 +577,8 @@ func TestResetStreamNoOp(t *testing.T) {
 
 func TestListStreamsFail(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, fmt.Errorf("pop")).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, fmt.Errorf("pop")).Once()
 	})
 	defer done()
 
@@ -562,8 +589,8 @@ func TestListStreamsFail(t *testing.T) {
 
 func TestGetStreamByIDFail(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByID", mock.Anything, mock.Anything).Return((*EventStreamSpec[testESConfig])(nil), fmt.Errorf("pop")).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetByID", mock.Anything, mock.Anything).Return((*GenericEventStream)(nil), fmt.Errorf("pop")).Once()
 	})
 	defer done()
 
@@ -574,8 +601,8 @@ func TestGetStreamByIDFail(t *testing.T) {
 
 func TestGetStreamByNameOrID(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
-		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&EventStreamSpec[testESConfig]{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(&GenericEventStream{}, nil).Once()
 	})
 	defer done()
 
@@ -586,17 +613,20 @@ func TestGetStreamByNameOrID(t *testing.T) {
 
 func TestCloseSuspendFail(t *testing.T) {
 	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
-		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil).Once()
 	})
 	done()
 
-	existing := &eventStream[testESConfig, testData]{
-		spec: &EventStreamSpec[testESConfig]{
-			ID:     ptrTo(fftypes.NewUUID().String()),
-			Name:   ptrTo("stream1"),
-			Status: ptrTo(EventStreamStatusStopped),
+	existing := &eventStream[*GenericEventStream, testData]{
+		spec: &GenericEventStream{
+			ResourceBase: dbsql.ResourceBase{ID: fftypes.NewUUID()},
+			EventStreamSpecFields: EventStreamSpecFields{
+				Name:   ptrTo("stream1"),
+				Status: ptrTo(EventStreamStatusStopped),
+			},
 		},
-		activeState: &activeStream[testESConfig, testData]{},
+		esm:         esm,
+		activeState: &activeStream[*GenericEventStream, testData]{},
 		stopping:    make(chan struct{}),
 	}
 	esm.addStream(ctx, existing)

--- a/pkg/eventstreams/manager_test.go
+++ b/pkg/eventstreams/manager_test.go
@@ -570,8 +570,13 @@ func TestResetStreamNoOp(t *testing.T) {
 	existing.esm = esm
 
 	esm.addStream(ctx, existing)
-	err := esm.ResetStream(ctx, existing.spec.GetID(), "12345")
+	called := false
+	err := esm.ResetStream(ctx, existing.spec.GetID(), "12345", func(_ context.Context, spec *GenericEventStream) {
+		called = true
+		assert.Equal(t, existing.spec, spec)
+	})
 	assert.NoError(t, err)
+	assert.True(t, called)
 
 }
 

--- a/pkg/eventstreams/persistence.go
+++ b/pkg/eventstreams/persistence.go
@@ -100,6 +100,8 @@ func (ges *GenericEventStream) WithRuntimeStatus(status EventStreamStatus, stats
 		ResourceBase:          ges.ResourceBase,
 		Type:                  ges.Type,
 		EventStreamSpecFields: ges.EventStreamSpecFields,
+		Webhook:               ges.Webhook,
+		WebSocket:             ges.WebSocket,
 		Statistics:            stats,
 	}
 	newGES.Status = &status

--- a/pkg/eventstreams/persistence.go
+++ b/pkg/eventstreams/persistence.go
@@ -140,7 +140,6 @@ func (p *esPersistence[CT]) EventStreams() dbsql.CRUD[*GenericEventStream] {
 			"type",
 			"initial_sequence_id",
 			"topic_filter",
-			"identity",
 			"error_handling",
 			"batch_size",
 			"batch_timeout",
@@ -178,8 +177,6 @@ func (p *esPersistence[CT]) EventStreams() dbsql.CRUD[*GenericEventStream] {
 				return &inst.InitialSequenceID
 			case "topic_filter":
 				return &inst.TopicFilter
-			case "identity":
-				return &inst.Identity
 			case "error_handling":
 				return &inst.ErrorHandling
 			case "batch_size":

--- a/pkg/eventstreams/websockets_test.go
+++ b/pkg/eventstreams/websockets_test.go
@@ -37,16 +37,16 @@ func mockWSChannels(wsc *wsservermocks.WebSocketChannels) (chan interface{}, cha
 	return senderChannel, broadcastChannel, receiverChannel
 }
 
-func newTestWebSocketsFactory(t *testing.T) (context.Context, *esManager[testESConfig, testData], *wsservermocks.WebSocketChannels, *webSocketDispatcherFactory[testESConfig, testData]) {
+func newTestWebSocketsFactory(t *testing.T) (context.Context, *esManager[*GenericEventStream, testData], *wsservermocks.WebSocketChannels, *webSocketDispatcherFactory[*GenericEventStream, testData]) {
 	ctx, mgr, _, done := newMockESManager(t, func(mdb *mockPersistence) {
-		mdb.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil)
+		mdb.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*GenericEventStream{}, &ffapi.FilterResult{}, nil)
 	})
 	done()
 
 	mws := wsservermocks.NewWebSocketChannels(t)
 	mgr.wsChannels = mws
 
-	return ctx, mgr, mws, &webSocketDispatcherFactory[testESConfig, testData]{esm: mgr}
+	return ctx, mgr, mws, &webSocketDispatcherFactory[*GenericEventStream, testData]{esm: mgr}
 }
 
 func TestWSAttemptIgnoreWrongAcks(t *testing.T) {
@@ -64,8 +64,10 @@ func TestWSAttemptIgnoreWrongAcks(t *testing.T) {
 	}()
 
 	dmw := DistributionModeBroadcast
-	spec := &EventStreamSpec[testESConfig]{
-		Name: ptrTo("ut_stream"),
+	spec := &GenericEventStream{
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name: ptrTo("ut_stream"),
+		},
 		WebSocket: &WebSocketConfig{
 			DistributionMode: &dmw,
 		},
@@ -92,8 +94,10 @@ func TestWSattemptDispatchExitPushingEvent(t *testing.T) {
 	bc <- []*fftypes.JSONAny{} // block the broadcast channel
 
 	dmw := DistributionModeBroadcast
-	spec := &EventStreamSpec[testESConfig]{
-		Name: ptrTo("ut_stream"),
+	spec := &GenericEventStream{
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name: ptrTo("ut_stream"),
+		},
 		WebSocket: &WebSocketConfig{
 			DistributionMode: &dmw,
 		},
@@ -119,8 +123,10 @@ func TestWSattemptDispatchExitReceivingReply(t *testing.T) {
 	_, _, rc := mockWSChannels(mws)
 
 	dmw := DistributionModeBroadcast
-	spec := &EventStreamSpec[testESConfig]{
-		Name: ptrTo("ut_stream"),
+	spec := &GenericEventStream{
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name: ptrTo("ut_stream"),
+		},
 		WebSocket: &WebSocketConfig{
 			DistributionMode: &dmw,
 		},
@@ -143,8 +149,10 @@ func TestWSattemptDispatchNackFromClient(t *testing.T) {
 	}
 
 	dmw := DistributionModeBroadcast
-	spec := &EventStreamSpec[testESConfig]{
-		Name: ptrTo("ut_stream"),
+	spec := &GenericEventStream{
+		EventStreamSpecFields: EventStreamSpecFields{
+			Name: ptrTo("ut_stream"),
+		},
 		WebSocket: &WebSocketConfig{
 			DistributionMode: &dmw,
 		},

--- a/pkg/i18n/en_base_field_descriptions.go
+++ b/pkg/i18n/en_base_field_descriptions.go
@@ -51,7 +51,6 @@ var (
 	EventStreamUpdated           = ffm("eventstream.updated", "Time the event stream was last updated")
 	EventStreamErrorHandling     = ffm("eventstream.errorHandling", "When an error is encountered, and short retries are exhausted, whether to skip the event or block the stream (default=block)")
 	EventStreamID                = ffm("eventstream.id", "ID of the event stream")
-	EventStreamIdentity          = ffm("eventstream.identity", "Identity context for the event stream")
 	EventStreamInitialSequenceID = ffm("eventstream.initialSequenceID", "Initial sequence ID to begin event delivery from")
 	EventStreamName              = ffm("eventstream.name", "Unique name for the event stream")
 	EventStreamRetryTimeout      = ffm("eventstream.retryTimeout", "Short retry timeout before error handling, in case of webhook based delivery")

--- a/pkg/i18n/en_base_field_descriptions.go
+++ b/pkg/i18n/en_base_field_descriptions.go
@@ -51,7 +51,7 @@ var (
 	EventStreamUpdated           = ffm("eventstream.updated", "Time the event stream was last updated")
 	EventStreamErrorHandling     = ffm("eventstream.errorHandling", "When an error is encountered, and short retries are exhausted, whether to skip the event or block the stream (default=block)")
 	EventStreamID                = ffm("eventstream.id", "ID of the event stream")
-	EventStreamInitialSequenceID = ffm("eventstream.initialSequenceID", "Initial sequence ID to begin event delivery from")
+	EventStreamInitialSequenceID = ffm("eventstream.initialSequenceId", "Initial sequence ID to begin event delivery from")
 	EventStreamName              = ffm("eventstream.name", "Unique name for the event stream")
 	EventStreamRetryTimeout      = ffm("eventstream.retryTimeout", "Short retry timeout before error handling, in case of webhook based delivery")
 	EventStreamStatus            = ffm("eventstream.status", "Status information for the event stream")

--- a/test/es_demo_migrations/000001_create_eventstreams_table.up.sql
+++ b/test/es_demo_migrations/000001_create_eventstreams_table.up.sql
@@ -9,7 +9,6 @@ CREATE TABLE eventstreams (
   initial_sequence_id  TEXT,
   topic_filter         TEXT,
   identity             TEXT,
-  config               TEXT,
   error_handling       TEXT,
   batch_size           INT,
   batch_timeout        BIGINT,


### PR DESCRIPTION
I've hit some problems in having enough flexibility on the Event Streams package, and this PR proposes to solve these:
1. The `config` sub-section on the input/output object is odd
   - You configure `websockets`/`webhooks` with a sub-structure named the same name at the top level, why if you're doing something else do you have to nest it underneath a random `config` JSON
2. Removing access to the `type` field - I have some cases where ES are exposed in multiple API endpoints, with different restrictions on the type. Specifically one case where the configuration for using event streams internally, vs. externally.
3. Removing advertising `webhooks`/`websockets` fields, if those types are not actually used
4. Customizing the persistence implementation, rather coupled to 1-3 above.

Overall this approach makes the package more flexible, and while it requires a small change to consumers (per the example one), I believe all previous cases can be solved without DB migration.

Also fixes a significant issue, where the foreground context of a HTTP call is used to init a stream on `UpsertStream`.