### PR TITLE
fix: delete stream with name

### DIFF
--- a/pkg/eventstreams/e2e_test.go
+++ b/pkg/eventstreams/e2e_test.go
@@ -464,7 +464,7 @@ func TestE2E_CRUDLifecycle(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Delete the first stream (which is running still)
-	err = mgr.DeleteStream(ctx, es1.GetID())
+	err = mgr.DeleteStream(ctx, *es1.Name)
 	assert.NoError(t, err)
 
 	// Check no streams left

--- a/pkg/eventstreams/manager.go
+++ b/pkg/eventstreams/manager.go
@@ -261,7 +261,7 @@ func (esm *esManager[CT, DT]) DeleteStream(ctx context.Context, nameOrID string)
 		return err
 	}
 	// Now we can delete it fully from the DB
-	if err := esm.persistence.EventStreams().Delete(ctx, nameOrID); err != nil {
+	if err := esm.persistence.EventStreams().Delete(ctx, es.spec.GetID()); err != nil {
 		return err
 	}
 	esm.removeStream(es.spec.GetID())

--- a/pkg/eventstreams/manager_test.go
+++ b/pkg/eventstreams/manager_test.go
@@ -475,6 +475,27 @@ func TestDeleteStreamFailDelete(t *testing.T) {
 
 }
 
+func TestDeleteStreamByName(t *testing.T) {
+	es := &EventStreamSpec[testESConfig]{
+		ID:     ptrTo(fftypes.NewUUID().String()),
+		Name:   ptrTo("stream1"),
+		Status: ptrTo(EventStreamStatusStopped),
+	}
+	ctx, esm, _, done := newMockESManager(t, func(mp *mockPersistence) {
+		mp.eventStreams.On("GetByUUIDOrName", mock.Anything, mock.Anything).Return(es, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{es}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("GetMany", mock.Anything, mock.Anything).Return([]*EventStreamSpec[testESConfig]{}, &ffapi.FilterResult{}, nil).Once()
+		mp.eventStreams.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		// Expect the ID to be passed to delete
+		mp.eventStreams.On("Delete", mock.Anything, *es.ID).Return(nil).Once()
+	})
+	defer done()
+
+	err := esm.DeleteStream(ctx, *es.Name)
+	assert.Regexp(t, "pop", err)
+
+}
+
 func TestResetStreamStopFailTimeout(t *testing.T) {
 	existing := &eventStream[*GenericEventStream, testData]{
 		activeState: &activeStream[*GenericEventStream, testData]{},


### PR DESCRIPTION
When deleting we add an IDFilter so that the SQL query results in `DELETE FROM table WHERE ID = <value>` in the case of deleting stream we were passing the nameOrID to that SQL query and it was failing when we passed the name. Since we retrieve the value from the DB before deleting we can just pass in the ID to delete