### PR TITLE
fix: Change how we index the filter operations before evaluation

### DIFF
--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -210,13 +210,7 @@ func (jq *QueryJSON) addSimpleFilters(ctx context.Context, fb FilterBuilder, jso
 func joinShortNames(long, short, negated []*FilterJSONKeyValue) []*FilterJSONKeyValue {
 	res := make([]*FilterJSONKeyValue, len(long)+len(short)+len(negated))
 	copy(res, long)
-
-	if len(long) == 0 {
-		copy(res[0:], short)
-	} else {
-		copy(res[len(long):], short)
-	}
-
+	copy(res[len(long):], short)
 	negs := res[len(short)+len(long):]
 	copy(negs, negated)
 	for _, n := range negs {

--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -210,7 +210,13 @@ func (jq *QueryJSON) addSimpleFilters(ctx context.Context, fb FilterBuilder, jso
 func joinShortNames(long, short, negated []*FilterJSONKeyValue) []*FilterJSONKeyValue {
 	res := make([]*FilterJSONKeyValue, len(long)+len(short)+len(negated))
 	copy(res, long)
-	copy(res[len(short):], short)
+
+	if len(long) == 0 {
+		copy(res[0:], short)
+	} else {
+		copy(res[len(short):], short)
+	}
+
 	negs := res[len(short)+len(long):]
 	copy(negs, negated)
 	for _, n := range negs {

--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -214,7 +214,7 @@ func joinShortNames(long, short, negated []*FilterJSONKeyValue) []*FilterJSONKey
 	if len(long) == 0 {
 		copy(res[0:], short)
 	} else {
-		copy(res[len(short):], short)
+		copy(res[len(long):], short)
 	}
 
 	negs := res[len(short)+len(long):]


### PR DESCRIPTION
Crashes have been observed when using query filters that have a single `eq` operator in them, this changes the logic so that we actually index the array correctly for these kinds of filters.

(Also adds tests for other short-name operations to prove that those work as intended too.)