### PR TITLE
Fix SQL query time reporting in log messages

### DIFF
--- a/pkg/dbsql/database.go
+++ b/pkg/dbsql/database.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -462,7 +462,7 @@ func (s *Database) CommitTx(ctx context.Context, tx *TXWrapper, autoCommit bool)
 }
 
 func floatMillisSince(t time.Time) float64 {
-	return (float64)(time.Since(t).Milliseconds()) / (float64)(time.Millisecond)
+	return (float64)(time.Since(t)) / (float64)(time.Millisecond)
 }
 
 func (s *Database) DB() *sql.DB {

--- a/pkg/dbsql/database_test.go
+++ b/pkg/dbsql/database_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	sq "github.com/Masterminds/squirrel"
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -132,6 +133,7 @@ func TestQueryTxBadSQL(t *testing.T) {
 }
 
 func TestQueryNoTxOk(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
 	mp, mdb := NewMockProvider().UTInit()
 	mdb.ExpectQuery("SELECT.*").WillReturnRows(sqlmock.NewRows([]string{"seq"}).AddRow(12345))
 	f := TestQueryFactory.NewFilter(context.Background()).Eq("id", "12345")


### PR DESCRIPTION
Debug log entries always incorrectly coming out as `(0.00ms)` due to double-dividing by the `time.Milliseconds`