### PR TITLE
Add ability to selectively ignore adding a route into the OpenAPI document

### DIFF
--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -102,6 +102,10 @@ func (sg *SwaggerGen) Generate(ctx context.Context, routes []*Route) *openapi3.T
 		if route.Name == "" || opIds[route.Name] {
 			log.Panicf("Duplicate/invalid name (used as operation ID in swagger): %s", route.Name)
 		}
+		// Not adding route to OpenAPI if flag set
+		if route.IgnoreFromOpenAPI {
+			continue
+		}
 		sg.addRoute(ctx, doc, route)
 		opIds[route.Name] = true
 	}

--- a/pkg/ffapi/routes.go
+++ b/pkg/ffapi/routes.go
@@ -73,6 +73,8 @@ type Route struct {
 	Tag string
 	// Extensions allows extension of the route struct by individual microservices
 	Extensions interface{}
+	// IgnoreFromOpenAPI is a flag to not add this route to the OpenAPI document generated
+	IgnoreFromOpenAPI bool
 }
 
 // PathParam is a description of a path parameter


### PR DESCRIPTION
Allow at the Route level to choose to add it to the OpenAPI generated or not