### PR TITLE
fix: empty stream state on broadcast

### DIFF
--- a/pkg/eventstreams/websockets.go
+++ b/pkg/eventstreams/websockets.go
@@ -80,7 +80,8 @@ func (w *webSocketAction[DT]) AttemptDispatch(ctx context.Context, attempt int, 
 	isBroadcast := *w.spec.DistributionMode == DistributionModeBroadcast
 
 	if isBroadcast {
-		return w.wsProtocol.Broadcast(ctx, w.topic, batch)
+		w.wsProtocol.Broadcast(ctx, w.topic, batch)
+		return nil
 	}
 
 	_, err = w.wsProtocol.RoundTrip(ctx, w.topic, batch)

--- a/pkg/eventstreams/websockets.go
+++ b/pkg/eventstreams/websockets.go
@@ -80,8 +80,7 @@ func (w *webSocketAction[DT]) AttemptDispatch(ctx context.Context, attempt int, 
 	isBroadcast := *w.spec.DistributionMode == DistributionModeBroadcast
 
 	if isBroadcast {
-		w.wsProtocol.Broadcast(ctx, w.topic, batch)
-		return nil
+		return w.wsProtocol.Broadcast(ctx, w.topic, batch)
 	}
 
 	_, err = w.wsProtocol.RoundTrip(ctx, w.topic, batch)

--- a/pkg/wsserver/wsserver.go
+++ b/pkg/wsserver/wsserver.go
@@ -136,15 +136,8 @@ func (s *webSocketServer) Broadcast(ctx context.Context, stream string, payload 
 	s.mux.Lock()
 	ss := s.streamMap[stream]
 	if ss == nil {
-		s.mux.Unlock()
-		// Waiting for a least one connection to start the stream
-		// before we start broadcasting
-		// Err always nil per callback function
-		_ = s.waitStreamConnections(ctx, stream, func(providedState *streamState) error {
-			ss = providedState
-			return nil
-		})
-		s.mux.Lock()
+		ss = &streamState{}
+		s.streamMap[stream] = ss
 	}
 	conns := make([]*webSocketConnection, len(ss.conns))
 	copy(conns, ss.conns)

--- a/pkg/wsserver/wsserver.go
+++ b/pkg/wsserver/wsserver.go
@@ -139,13 +139,11 @@ func (s *webSocketServer) Broadcast(ctx context.Context, stream string, payload 
 		s.mux.Unlock()
 		// Waiting for a least one connection to start the stream
 		// before we start broadcasting
-		err := s.waitStreamConnections(ctx, stream, func(providedState *streamState) error {
+		// Err always nil per callback function
+		_ = s.waitStreamConnections(ctx, stream, func(providedState *streamState) error {
 			ss = providedState
 			return nil
 		})
-		if err != nil {
-			return err
-		}
 		s.mux.Lock()
 	}
 	conns := make([]*webSocketConnection, len(ss.conns))

--- a/pkg/wsserver/wsserver.go
+++ b/pkg/wsserver/wsserver.go
@@ -38,7 +38,7 @@ import (
 //	and attempted to solve the above problem set in a different way that had a challenging timing issue.
 type Protocol interface {
 	// Broadcast performs best-effort delivery to all connections currently active on the specified stream
-	Broadcast(ctx context.Context, stream string, payload interface{}) error
+	Broadcast(ctx context.Context, stream string, payload interface{})
 
 	// NextRoundTrip blocks until at least one connection is started on the stream, and then
 	// returns an interface that can be used to send a payload to exactly one of the attached
@@ -132,7 +132,7 @@ func (s *webSocketServer) Close() {
 	}
 }
 
-func (s *webSocketServer) Broadcast(ctx context.Context, stream string, payload interface{}) error {
+func (s *webSocketServer) Broadcast(ctx context.Context, stream string, payload interface{}) {
 	s.mux.Lock()
 	ss := s.streamMap[stream]
 	if ss == nil {
@@ -150,8 +150,6 @@ func (s *webSocketServer) Broadcast(ctx context.Context, stream string, payload 
 			log.L(ctx).Warnf("broadcast failed to closing connection '%s'", c.id)
 		}
 	}
-
-	return nil
 }
 
 type roundTrip struct {

--- a/pkg/wsserver/wsserver_test.go
+++ b/pkg/wsserver/wsserver_test.go
@@ -359,6 +359,35 @@ func TestConnectBadWebsocketHandshake(t *testing.T) {
 
 }
 
+func TestBroadcastStartWithoutConnections(t *testing.T) {
+	assert := assert.New(t)
+
+	w, ts := newTestWebSocketServer()
+	defer ts.Close()
+	defer w.Close()
+
+	u, _ := url.Parse(ts.URL)
+	u.Scheme = "ws"
+	u.Path = "/ws"
+	stream := "banana"
+
+	go w.Broadcast(w.ctx, stream, "Hello World")
+
+	c1, _, err := ws.DefaultDialer.Dial(u.String(), nil)
+	assert.NoError(err)
+	c1.WriteJSON(&WebSocketCommandMessage{
+		Type:   "start",
+		Stream: stream,
+	})
+
+	c2, _, err := ws.DefaultDialer.Dial(u.String(), nil)
+	assert.NoError(err)
+	c2.WriteJSON(&WebSocketCommandMessage{
+		Type:   "start",
+		Stream: stream,
+	})
+}
+
 func TestBroadcast(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
When a broadcast is attempted and the steam state hasn't been initialise it caused a nil pointer.

Two ways to solve this:
- If the stream state is nil, set an empty one as part of broadcast but that means no connections will receive those messages until that map updates 
- Wait for a least one connection on this stream to start and then start broadcasting. At least one connection will receive the messages for the stream whilst it's connected

I've gone for the latter one. We perform best-effort delivery for broadcast, so it could be argued to do the former, any thoughts appreciated! 