### PR TITLE
Do not log an error if a JSON field is missing

### DIFF
--- a/pkg/fftypes/jsonobject.go
+++ b/pkg/fftypes/jsonobject.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -133,8 +133,8 @@ func (jd JSONObject) GetObject(key string) JSONObject {
 }
 
 func (jd JSONObject) GetObjectOk(key string) (JSONObject, bool) {
-	vInterace, ok := jd[key]
-	if ok && vInterace != nil {
+	vInterface, ok := jd[key]
+	if ok && vInterface != nil {
 		vInterface := jd[key]
 		switch vMap := vInterface.(type) {
 		case map[string]interface{}:
@@ -142,7 +142,7 @@ func (jd JSONObject) GetObjectOk(key string) (JSONObject, bool) {
 		case JSONObject:
 			return vMap, true
 		default:
-			log.L(context.Background()).Errorf("Invalid object value '%+v' for key '%s'", vInterace, key)
+			log.L(context.Background()).Errorf("Invalid object value '%+v' for key '%s'", vInterface, key)
 			return JSONObject{}, false // Ensures a non-nil return
 		}
 	}
@@ -187,11 +187,10 @@ func (jd JSONObject) GetObjectArray(key string) JSONObjectArray {
 }
 
 func (jd JSONObject) GetObjectArrayOk(key string) (JSONObjectArray, bool) {
-	vInterace, ok := jd[key]
-	if ok && vInterace != nil {
-		return ToJSONObjectArray(vInterace)
+	vInterface, ok := jd[key]
+	if ok && vInterface != nil {
+		return ToJSONObjectArray(vInterface)
 	}
-	log.L(context.Background()).Errorf("Invalid object value '%+v' for key '%s'", vInterace, key)
 	return JSONObjectArray{}, false // Ensures a non-nil return
 }
 
@@ -201,11 +200,11 @@ func (jd JSONObject) GetStringArray(key string) []string {
 }
 
 func (jd JSONObject) GetStringArrayOk(key string) ([]string, bool) {
-	vInterace, ok := jd[key]
-	if ok && vInterace != nil {
-		return ToStringArray(vInterace)
+	vInterface, ok := jd[key]
+	if ok && vInterface != nil {
+		return ToStringArray(vInterface)
 	}
-	log.L(context.Background()).Errorf("Invalid string array value '%+v' for key '%s'", vInterace, key)
+	log.L(context.Background()).Errorf("Invalid string array value '%+v' for key '%s'", vInterface, key)
 	return []string{}, false // Ensures a non-nil return
 }
 


### PR DESCRIPTION
Previously, this code would log an error if an array was not present in the JSON object structure (on the background context). This causes FireFLy Core to log things like this when it starts up:

```
[2024-02-22T17:53:58.799Z] DEBUG Log level: debug pid=1
[2024-02-22T17:53:58.802Z]  INFO Hyperledger FireFly pid=1
[2024-02-22T17:53:58.802Z]  INFO © Copyright 2022 Kaleido, Inc. pid=1
[2024-02-22T17:53:58.803Z]  INFO Starting up pid=1
[2024-02-22T17:53:58.806Z] DEBUG Debug HTTP endpoint listening on localhost:6060 pid=1
[2024-02-22T17:53:58.835Z] ERROR Invalid object value '<nil>' for key 'identity'
[2024-02-22T17:53:58.844Z] ERROR Invalid object value '<nil>' for key 'auth'
```

Even though these fields are optional, the error logs make it look like something is wrong with the config which is confusing to people. I believe we can omit this log entirely in the case that the array is not present `nil`, as the `ok` value will indicate to the calling code whether the field was found or not.