### PR TITLE
[fftls] Allow for In-Memory or Inlined TLS Certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOGC=30
 .DELETE_ON_ERROR:
 
 all: build test go-mod-tidy
-test: deps
+test: deps lint
 		$(VGO) test ./pkg/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
 coverage.html:
 		$(VGO) tool cover -html=coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOGC=30
 .DELETE_ON_ERROR:
 
 all: build test go-mod-tidy
-test: deps lint
+test: deps
 		$(VGO) test ./pkg/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
 coverage.html:
 		$(VGO) tool cover -html=coverage.txt

--- a/pkg/fftls/config.go
+++ b/pkg/fftls/config.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fftls/config.go
+++ b/pkg/fftls/config.go
@@ -23,14 +23,21 @@ import (
 const (
 	// HTTPConfTLSCAFile the TLS certificate authority file for the HTTP server
 	HTTPConfTLSCAFile = "caFile"
+	// HTTPConfTLSCA the TLS certificate authority in PEM format
+	HTTPConfTLSCA = "ca"
 	// HTTPConfTLSCertFile the TLS certificate file for the HTTP server
 	HTTPConfTLSCertFile = "certFile"
+	// HTTPConfTLSCert the TLS certificate in PEM format
+	HTTPConfTLSCert = "cert"
 	// HTTPConfTLSClientAuth whether the HTTP server requires a mutual TLS connection
 	HTTPConfTLSClientAuth = "clientAuth"
 	// HTTPConfTLSEnabled whether TLS is enabled for the HTTP server
 	HTTPConfTLSEnabled = "enabled"
 	// HTTPConfTLSKeyFile the private key file for TLS on the server
 	HTTPConfTLSKeyFile = "keyFile"
+	// HTTPConfTLSKey the TLS certificate key in PEM format
+	HTTPConfTLSKey = "key"
+
 	// HTTPConfTLSInsecureSkipHostVerify disables host verification - insecure (for dev only)
 	HTTPConfTLSInsecureSkipHostVerify = "insecureSkipHostVerify"
 
@@ -44,8 +51,11 @@ type Config struct {
 	Enabled                bool                   `ffstruct:"tlsconfig" json:"enabled"`
 	ClientAuth             bool                   `ffstruct:"tlsconfig" json:"clientAuth,omitempty"`
 	CAFile                 string                 `ffstruct:"tlsconfig" json:"caFile,omitempty"`
+	CA                     string                 `ffstruct:"tlsconfig" json:"ca,omitempty"`
 	CertFile               string                 `ffstruct:"tlsconfig" json:"certFile,omitempty"`
+	Cert                   string                 `ffstruct:"tlsconfig" json:"cert,omitempty"`
 	KeyFile                string                 `ffstruct:"tlsconfig" json:"keyFile,omitempty"`
+	Key                    string                 `ffstruct:"tlsconfig" json:"key,omitempty"`
 	InsecureSkipHostVerify bool                   `ffstruct:"tlsconfig" json:"insecureSkipHostVerify"`
 	RequiredDNAttributes   map[string]interface{} `ffstruct:"tlsconfig" json:"requiredDNAttributes,omitempty"`
 }
@@ -53,9 +63,12 @@ type Config struct {
 func InitTLSConfig(conf config.Section) {
 	conf.AddKnownKey(HTTPConfTLSEnabled, defaultHTTPTLSEnabled)
 	conf.AddKnownKey(HTTPConfTLSCAFile)
+	conf.AddKnownKey(HTTPConfTLSCA)
 	conf.AddKnownKey(HTTPConfTLSClientAuth)
 	conf.AddKnownKey(HTTPConfTLSCertFile)
+	conf.AddKnownKey(HTTPConfTLSCert)
 	conf.AddKnownKey(HTTPConfTLSKeyFile)
+	conf.AddKnownKey(HTTPConfTLSKey)
 	conf.AddKnownKey(HTTPConfTLSRequiredDNAttributes)
 	conf.AddKnownKey(HTTPConfTLSInsecureSkipHostVerify)
 }
@@ -65,8 +78,11 @@ func GenerateConfig(conf config.Section) *Config {
 		Enabled:                conf.GetBool(HTTPConfTLSEnabled),
 		ClientAuth:             conf.GetBool(HTTPConfTLSClientAuth),
 		CAFile:                 conf.GetString(HTTPConfTLSCAFile),
+		CA:                     conf.GetString(HTTPConfTLSCA),
 		CertFile:               conf.GetString(HTTPConfTLSCertFile),
+		Cert:                   conf.GetString(HTTPConfTLSCert),
 		KeyFile:                conf.GetString(HTTPConfTLSKeyFile),
+		Key:                    conf.GetString(HTTPConfTLSKey),
 		InsecureSkipHostVerify: conf.GetBool(HTTPConfTLSInsecureSkipHostVerify),
 		RequiredDNAttributes:   conf.GetObject(HTTPConfTLSRequiredDNAttributes),
 	}

--- a/pkg/fftls/config.go
+++ b/pkg/fftls/config.go
@@ -23,11 +23,11 @@ import (
 const (
 	// HTTPConfTLSCAFile the TLS certificate authority file for the HTTP server
 	HTTPConfTLSCAFile = "caFile"
-	// HTTPConfTLSCA the TLS certificate authority in PEM format
+	// HTTPConfTLSCA the TLS certificate authority in PEM format, this option is ignored if HTTPConfTLSCAFile is also set
 	HTTPConfTLSCA = "ca"
 	// HTTPConfTLSCertFile the TLS certificate file for the HTTP server
 	HTTPConfTLSCertFile = "certFile"
-	// HTTPConfTLSCert the TLS certificate in PEM format
+	// HTTPConfTLSCert the TLS certificate in PEM format, this option is ignored if HTTPConfTLSCertFile is also set
 	HTTPConfTLSCert = "cert"
 	// HTTPConfTLSClientAuth whether the HTTP server requires a mutual TLS connection
 	HTTPConfTLSClientAuth = "clientAuth"
@@ -35,7 +35,7 @@ const (
 	HTTPConfTLSEnabled = "enabled"
 	// HTTPConfTLSKeyFile the private key file for TLS on the server
 	HTTPConfTLSKeyFile = "keyFile"
-	// HTTPConfTLSKey the TLS certificate key in PEM format
+	// HTTPConfTLSKey the TLS certificate key in PEM format, this option is ignored if HTTPConfTLSKeyFile is also set
 	HTTPConfTLSKey = "key"
 
 	// HTTPConfTLSInsecureSkipHostVerify disables host verification - insecure (for dev only)

--- a/pkg/fftls/fftls.go
+++ b/pkg/fftls/fftls.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fftls/fftls.go
+++ b/pkg/fftls/fftls.go
@@ -62,7 +62,8 @@ func NewTLSConfig(ctx context.Context, config *Config, tlsType TLSType) (*tls.Co
 	var err error
 	// Support custom CA file
 	var rootCAs *x509.CertPool
-	if config.CAFile != "" {
+	switch {
+	case config.CAFile != "":
 		rootCAs = x509.NewCertPool()
 		var caBytes []byte
 		caBytes, err = os.ReadFile(config.CAFile)
@@ -72,13 +73,13 @@ func NewTLSConfig(ctx context.Context, config *Config, tlsType TLSType) (*tls.Co
 				err = i18n.NewError(ctx, i18n.MsgInvalidCAFile)
 			}
 		}
-	} else if config.CA != "" {
+	case config.CA != "":
 		rootCAs = x509.NewCertPool()
 		ok := rootCAs.AppendCertsFromPEM([]byte(config.CA))
 		if !ok {
 			err = i18n.NewError(ctx, i18n.MsgInvalidCAFile)
 		}
-	} else {
+	default:
 		rootCAs, err = x509.SystemCertPool()
 	}
 

--- a/pkg/fftls/fftls.go
+++ b/pkg/fftls/fftls.go
@@ -72,6 +72,12 @@ func NewTLSConfig(ctx context.Context, config *Config, tlsType TLSType) (*tls.Co
 				err = i18n.NewError(ctx, i18n.MsgInvalidCAFile)
 			}
 		}
+	} else if config.CA != "" {
+		rootCAs = x509.NewCertPool()
+		ok := rootCAs.AppendCertsFromPEM([]byte(config.CA))
+		if !ok {
+			err = i18n.NewError(ctx, i18n.MsgInvalidCAFile)
+		}
 	} else {
 		rootCAs, err = x509.SystemCertPool()
 	}
@@ -89,7 +95,12 @@ func NewTLSConfig(ctx context.Context, config *Config, tlsType TLSType) (*tls.Co
 		if err != nil {
 			return nil, i18n.WrapError(ctx, err, i18n.MsgInvalidKeyPairFiles)
 		}
-
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	} else if config.Cert != "" && config.Key != "" {
+		cert, err := tls.X509KeyPair([]byte(config.Cert), []byte(config.Key))
+		if err != nil {
+			return nil, i18n.WrapError(ctx, err, i18n.MsgInvalidKeyPairFiles)
+		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 

--- a/pkg/fftls/fftls_test.go
+++ b/pkg/fftls/fftls_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/fftls/fftls_test.go
+++ b/pkg/fftls/fftls_test.go
@@ -170,7 +170,22 @@ func TestErrInvalidCAFile(t *testing.T) {
 
 	_, err := ConstructTLSConfig(context.Background(), conf, ClientType)
 	assert.Regexp(t, "FF00152", err)
+}
 
+func TestErrInvalidCA(t *testing.T) {
+
+	config.RootConfigReset()
+	_, notTheCATheKey := buildSelfSignedTLSKeyPair(t, pkix.Name{
+		CommonName: "server.example.com",
+	})
+
+	conf := config.RootSection("fftls_server")
+	InitTLSConfig(conf)
+	conf.Set(HTTPConfTLSEnabled, true)
+	conf.Set(HTTPConfTLSCA, notTheCATheKey)
+
+	_, err := ConstructTLSConfig(context.Background(), conf, ClientType)
+	assert.Regexp(t, "FF00152", err)
 }
 
 func TestErrInvalidKeyPairFile(t *testing.T) {
@@ -185,6 +200,24 @@ func TestErrInvalidKeyPairFile(t *testing.T) {
 	conf.Set(HTTPConfTLSEnabled, true)
 	conf.Set(HTTPConfTLSKeyFile, notTheKeyFile)
 	conf.Set(HTTPConfTLSCertFile, notTheCertFile)
+
+	_, err := ConstructTLSConfig(context.Background(), conf, ClientType)
+	assert.Regexp(t, "FF00206", err)
+
+}
+
+func TestErrInvalidKeyPair(t *testing.T) {
+
+	config.RootConfigReset()
+	notTheKey, notTheCert := buildSelfSignedTLSKeyPair(t, pkix.Name{
+		CommonName: "server.example.com",
+	})
+
+	conf := config.RootSection("fftls_server")
+	InitTLSConfig(conf)
+	conf.Set(HTTPConfTLSEnabled, true)
+	conf.Set(HTTPConfTLSKey, notTheKey)
+	conf.Set(HTTPConfTLSCert, notTheCert)
 
 	_, err := ConstructTLSConfig(context.Background(), conf, ClientType)
 	assert.Regexp(t, "FF00206", err)

--- a/pkg/fftls/fftls_test.go
+++ b/pkg/fftls/fftls_test.go
@@ -24,9 +24,11 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"github.com/stretchr/testify/require"
 	"math/big"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +37,34 @@ import (
 )
 
 func buildSelfSignedTLSKeyPair(t *testing.T, subject pkix.Name) (string, string) {
+	// Create an X509 certificate pair
+	privatekey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publickey := &privatekey.PublicKey
+	var privateKeyBytes []byte = x509.MarshalPKCS1PrivateKey(privatekey)
+	privateKeyBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privateKeyBytes}
+	privateKeyPEM := &strings.Builder{}
+	err := pem.Encode(privateKeyPEM, privateKeyBlock)
+	require.NoError(t, err)
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	x509Template := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               subject,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(100 * time.Second),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	require.NoError(t, err)
+	derBytes, err := x509.CreateCertificate(rand.Reader, x509Template, x509Template, publickey, privatekey)
+	require.NoError(t, err)
+	publicKeyPEM := &strings.Builder{}
+	err = pem.Encode(publicKeyPEM, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	require.NoError(t, err)
+	return publicKeyPEM.String(), privateKeyPEM.String()
+}
+
+func buildSelfSignedTLSKeyPairFiles(t *testing.T, subject pkix.Name) (string, string) {
 	// Create an X509 certificate pair
 	privatekey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publickey := &privatekey.PublicKey
@@ -129,7 +159,7 @@ func TestTLSDefault(t *testing.T) {
 func TestErrInvalidCAFile(t *testing.T) {
 
 	config.RootConfigReset()
-	_, notTheCAFileTheKey := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	_, notTheCAFileTheKey := buildSelfSignedTLSKeyPairFiles(t, pkix.Name{
 		CommonName: "server.example.com",
 	})
 
@@ -146,7 +176,7 @@ func TestErrInvalidCAFile(t *testing.T) {
 func TestErrInvalidKeyPairFile(t *testing.T) {
 
 	config.RootConfigReset()
-	notTheKeyFile, notTheCertFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	notTheKeyFile, notTheCertFile := buildSelfSignedTLSKeyPairFiles(t, pkix.Name{
 		CommonName: "server.example.com",
 	})
 
@@ -162,11 +192,10 @@ func TestErrInvalidKeyPairFile(t *testing.T) {
 }
 
 func TestMTLSOk(t *testing.T) {
-
-	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	serverPublicKey, serverKey := buildSelfSignedTLSKeyPair(t, pkix.Name{
 		CommonName: "server.example.com",
 	})
-	clientPublicKeyFile, clientKeyFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	clientPublicKey, clientKey := buildSelfSignedTLSKeyPair(t, pkix.Name{
 		CommonName: "client.example.com",
 	})
 
@@ -175,9 +204,9 @@ func TestMTLSOk(t *testing.T) {
 	serverConf := config.RootSection("fftls_server")
 	InitTLSConfig(serverConf)
 	serverConf.Set(HTTPConfTLSEnabled, true)
-	serverConf.Set(HTTPConfTLSCAFile, clientPublicKeyFile)
-	serverConf.Set(HTTPConfTLSCertFile, serverPublicKeyFile)
-	serverConf.Set(HTTPConfTLSKeyFile, serverKeyFile)
+	serverConf.Set(HTTPConfTLSCA, clientPublicKey)
+	serverConf.Set(HTTPConfTLSCert, serverPublicKey)
+	serverConf.Set(HTTPConfTLSKey, serverKey)
 	serverConf.Set(HTTPConfTLSClientAuth, true)
 
 	addr, done := buildTLSListener(t, serverConf, ServerType)
@@ -186,9 +215,9 @@ func TestMTLSOk(t *testing.T) {
 	clientConf := config.RootSection("fftls_client")
 	InitTLSConfig(clientConf)
 	clientConf.Set(HTTPConfTLSEnabled, true)
-	clientConf.Set(HTTPConfTLSCAFile, serverPublicKeyFile)
-	clientConf.Set(HTTPConfTLSCertFile, clientPublicKeyFile)
-	clientConf.Set(HTTPConfTLSKeyFile, clientKeyFile)
+	clientConf.Set(HTTPConfTLSCA, serverPublicKey)
+	clientConf.Set(HTTPConfTLSCert, clientPublicKey)
+	clientConf.Set(HTTPConfTLSKey, clientKey)
 
 	tlsConfig, err := ConstructTLSConfig(context.Background(), clientConf, ClientType)
 	assert.NoError(t, err)
@@ -208,7 +237,7 @@ func TestMTLSOk(t *testing.T) {
 
 func TestMTLSMissingClientCert(t *testing.T) {
 
-	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPairFiles(t, pkix.Name{
 		CommonName: "server.example.com",
 	})
 
@@ -243,10 +272,10 @@ func TestMTLSMissingClientCert(t *testing.T) {
 
 func TestMTLSMatchFullSubject(t *testing.T) {
 
-	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPairFiles(t, pkix.Name{
 		CommonName: "server.example.com",
 	})
-	clientPublicKeyFile, clientKeyFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	clientPublicKeyFile, clientKeyFile := buildSelfSignedTLSKeyPairFiles(t, pkix.Name{
 		CommonName:         "client.example.com",
 		Country:            []string{"GB"},
 		Organization:       []string{"hyperledger"},
@@ -306,10 +335,10 @@ func TestMTLSMatchFullSubject(t *testing.T) {
 
 func TestMTLSMismatchSubject(t *testing.T) {
 
-	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPairFiles(t, pkix.Name{
 		CommonName: "server.example.com",
 	})
-	clientPublicKeyFile, clientKeyFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	clientPublicKeyFile, clientKeyFile := buildSelfSignedTLSKeyPairFiles(t, pkix.Name{
 		CommonName: "wrong.example.com",
 	})
 
@@ -429,7 +458,7 @@ func TestMTLSDNValidatorEmptyChain(t *testing.T) {
 
 func TestConnectSkipVerification(t *testing.T) {
 
-	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPair(t, pkix.Name{
+	serverPublicKeyFile, serverKeyFile := buildSelfSignedTLSKeyPairFiles(t, pkix.Name{
 		CommonName: "server.example.com",
 	})
 


### PR DESCRIPTION
Useful for configs which want to inline the certs as large PEM blocks in their config files, or when constructing TLS configs from in-memory certificates (such as certificates downloaded from a Kubernetes Secret).