### PR TITLE
Do not add alias prefix to filter fields that are already qualified

### DIFF
--- a/pkg/dbsql/filter_sql.go
+++ b/pkg/dbsql/filter_sql.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -206,7 +206,7 @@ func (s *Database) mapFieldName(tableName, fieldName string, tm map[string]strin
 			field = mf
 		}
 	}
-	if tableName != "" {
+	if tableName != "" && !strings.Contains(field, ".") {
 		field = fmt.Sprintf("%s.%s", tableName, field)
 	}
 	return field


### PR DESCRIPTION
If a filter field contains "." then assume it is already qualified to the correct scope (similar to how we treat SELECT fields).