### PR TITLE
[log] WithLogFields for Configuring Larger Logging Contexts

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -48,6 +48,24 @@ func WithLogField(ctx context.Context, key, value string) context.Context {
 	return WithLogger(ctx, loggerFromContext(ctx).WithField(key, value))
 }
 
+func WithLogFields(ctx context.Context, keyValues ...string) context.Context {
+	if len(keyValues)%2 != 0 {
+		panic("odd number of key-value entry fields provided, cannot determine key-value pairs")
+	}
+
+	entry := loggerFromContext(ctx)
+	fields := logrus.Fields{}
+	for i := 0; i < len(keyValues); i += 2 {
+		key := keyValues[i]
+		value := keyValues[i+1]
+		if len(value) > 61 {
+			value = value[0:61] + "..."
+		}
+		fields[key] = value
+	}
+	return WithLogger(ctx, entry.WithFields(fields))
+}
+
 // LoggerFromContext returns the logger for the current context, or no logger if there is no context
 func loggerFromContext(ctx context.Context) *logrus.Entry {
 	logger := ctx.Value(ctxLogKey{})

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -82,3 +82,9 @@ func TestSetFormattingJSONEnabled(t *testing.T) {
 
 	L(context.Background()).Infof("JSON logs")
 }
+
+func TestLogWithFields(t *testing.T) {
+	l := WithLogFields(context.Background(), "func", "test", "component", "tester")
+
+	L(l).Infof("logging with several fields")
+}


### PR DESCRIPTION
In several case, one might want to set several key value pairs on the context. Currently you have to chain together nested `WithLogField` funcs to do so, which isn't very readable or user friendly.

This allows the users to do so with just a list of strings. Otherwise we could require a `logrus.Fields` struct to be directly provided if we want to avoid the odd-number-check-and-panic ?