### PR TITLE
Add support for 256 bit JSON numbers (vs. strings)

### DIFF
--- a/pkg/fftypes/jsonany.go
+++ b/pkg/fftypes/jsonany.go
@@ -78,6 +78,10 @@ func (h *JSONAny) Unmarshal(ctx context.Context, v interface{}) error {
 		return i18n.NewError(ctx, i18n.MsgNilOrNullObject)
 	}
 
+	if _, ok := v.(*float64); ok {
+		return i18n.NewError(ctx, i18n.MsgUnmarshalToFloat64NotSupported)
+	}
+
 	d := json.NewDecoder(strings.NewReader(h.String()))
 	d.UseNumber()
 	if err := d.Decode(v); err != nil {

--- a/pkg/i18n/en_base_error_messages.go
+++ b/pkg/i18n/en_base_error_messages.go
@@ -183,4 +183,5 @@ var (
 	MsgDBExecFailed                                = ffe("FF00245", "Database update failed")
 	MsgDBErrorBuildingStatement                    = ffe("FF00247", "Error building statement: %s")
 	MsgDBReadInsertTSFailed                        = ffe("FF00248", "Failed to read timestamp from database optimized upsert: %s")
+	MsgUnmarshalToFloat64NotSupported              = ffe("FF00249", "Unmarshalling to a float64 is not supported due to possible precision loss. Consider unmarshalling to an interface, json.Number or fftypes.JSONAny instead")
 )


### PR DESCRIPTION
This PR is related to `firefly-signer` PR https://github.com/hyperledger/firefly-signer/pull/76 and it provides support for large JSON numbers being handled by FireFly.

Most usage of Ethereum (and this library) includes use of large integers greater than 64bits in size.
For example ERC-20 tokens are often deployed using 18 digits of precision so "1 token" is 1000000000000000000.

The FireFly APIs are designed for this, and support supplying this data as strings in JSON, using decimal or hex numeric form. This is the safest way to pass information through JSON as many code implementations in various languages (including Golang by default) do not support serialization/parsing of JSON numbers larger than the safe Javascript maximum (2^53-1) or the safe float64 maximum. They also might lose precision on serialization/de-serialization.

However, the JSON number notation is capable of representing large numbers without the loss of precision.

FireFly currently limits JSON number input params to 64 bits in size. For Ethereum data types such as uint256, this prevents you being able to invoke/deploy smart contracts with params up to max-size(uint256).

So this issue is very specific to the use of JSON number (not JSON string) parameters

This PR uses `json.NewDecoder()` with `UseNumber()` within the existing `fftypes.Unmarhsal()` function to treat large numbers as `json.Number`, not `float64`. This does not affect unmarshalling strings or smaller size integers.