### PR TITLE
feat: Add DeepCopy method to JSONObject

### DIFF
--- a/pkg/fftypes/jsonobject.go
+++ b/pkg/fftypes/jsonobject.go
@@ -233,3 +233,7 @@ func (jd JSONObject) Hash(jsonDesc string) (*Bytes32, error) {
 	var b32 Bytes32 = sha256.Sum256(b)
 	return &b32, nil
 }
+
+func (jd JSONObject) DeepCopy() JSONObject {
+	return deepCopyMap(jd)
+}

--- a/pkg/fftypes/jsonobject_test.go
+++ b/pkg/fftypes/jsonobject_test.go
@@ -254,3 +254,50 @@ func TestJSONNestedSafeGet(t *testing.T) {
 	)
 
 }
+
+func TestDeepCopyBasic(t *testing.T) {
+	original := JSONObject{
+		"key1": "value1",
+		"key2": 123,
+		"key3": true,
+	}
+
+	copy := original.DeepCopy()
+
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original, copy)
+}
+
+func TestDeepCopyNested(t *testing.T) {
+	original := JSONObject{
+		"key1": JSONObject{
+			"nestedKey1": "nestedValue1",
+			"nestedKey2": 456,
+		},
+		"key2": []interface{}{"elem1", "elem2"},
+	}
+
+	copy := original.DeepCopy()
+
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original, copy)
+	assert.NotSame(t, original["key1"], copy["key1"])
+	assert.NotSame(t, original["key2"], copy["key2"])
+}
+
+func TestDeepCopyEmpty(t *testing.T) {
+	original := JSONObject{}
+
+	copy := original.DeepCopy()
+
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original, copy)
+}
+
+func TestDeepCopyNil(t *testing.T) {
+	var original JSONObject = nil
+
+	copy := original.DeepCopy()
+
+	assert.Nil(t, copy)
+}

--- a/pkg/fftypes/jsonobjectutils.go
+++ b/pkg/fftypes/jsonobjectutils.go
@@ -1,0 +1,53 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fftypes
+
+func deepCopyMap(original map[string]interface{}) map[string]interface{} {
+	if original == nil {
+		return nil
+	}
+	co := make(map[string]interface{}, len(original))
+	for key, value := range original {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			co[key] = deepCopyMap(v)
+		case []interface{}:
+			co[key] = deepCopySlice(v)
+		default:
+			co[key] = v
+		}
+	}
+	return co
+}
+
+func deepCopySlice(original []interface{}) []interface{} {
+	if original == nil {
+		return nil
+	}
+	co := make([]interface{}, len(original))
+	for i, value := range original {
+		switch v := value.(type) {
+		case map[string]interface{}:
+			co[i] = deepCopyMap(v)
+		case []interface{}:
+			co[i] = deepCopySlice(v)
+		default:
+			co[i] = v
+		}
+	}
+	return co
+}

--- a/pkg/fftypes/jsonobjectutils_test.go
+++ b/pkg/fftypes/jsonobjectutils_test.go
@@ -1,0 +1,133 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fftypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeepCopyMapNil(t *testing.T) {
+	original := map[string]interface{}(nil)
+	copy := deepCopyMap(original)
+	assert.Nil(t, copy)
+}
+
+func TestDeepCopyMapEmpty(t *testing.T) {
+	original := map[string]interface{}{}
+	copy := deepCopyMap(original)
+	assert.NotNil(t, copy)
+	assert.Empty(t, copy)
+}
+
+func TestDeepCopyMapSimple(t *testing.T) {
+	original := map[string]interface{}{
+		"key1": "value1",
+		"key2": 42,
+	}
+	copy := deepCopyMap(original)
+	assert.Equal(t, original, copy)
+}
+
+func TestDeepCopyMapNestedMap(t *testing.T) {
+	original := map[string]interface{}{
+		"key1": map[string]interface{}{
+			"nestedKey1": "nestedValue1",
+		},
+	}
+	copy := deepCopyMap(original)
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original["key1"], copy["key1"])
+}
+
+func TestDeepCopyMapNestedSlice(t *testing.T) {
+	original := map[string]interface{}{
+		"key1": []interface{}{"value1", 42},
+	}
+	copy := deepCopyMap(original)
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original["key1"], copy["key1"])
+}
+
+func TestDeepCopyMapMixed(t *testing.T) {
+	original := map[string]interface{}{
+		"key1": "value1",
+		"key2": map[string]interface{}{
+			"nestedKey1": "nestedValue1",
+		},
+		"key3": []interface{}{"value1", 42},
+	}
+	copy := deepCopyMap(original)
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original["key2"], copy["key2"])
+	assert.NotSame(t, original["key3"], copy["key3"])
+}
+
+func TestDeepCopySliceNil(t *testing.T) {
+	original := []interface{}(nil)
+	copy := deepCopySlice(original)
+	assert.Nil(t, copy)
+}
+
+func TestDeepCopySliceEmpty(t *testing.T) {
+	original := []interface{}{}
+	copy := deepCopySlice(original)
+	assert.NotNil(t, copy)
+	assert.Empty(t, copy)
+}
+
+func TestDeepCopySliceSimple(t *testing.T) {
+	original := []interface{}{"value1", 42}
+	copy := deepCopySlice(original)
+	assert.Equal(t, original, copy)
+}
+
+func TestDeepCopySliceNestedMap(t *testing.T) {
+	original := []interface{}{
+		map[string]interface{}{
+			"nestedKey1": "nestedValue1",
+		},
+	}
+	copy := deepCopySlice(original)
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original[0], copy[0])
+}
+
+func TestDeepCopySliceNestedSlice(t *testing.T) {
+	original := []interface{}{
+		[]interface{}{"value1", 42},
+	}
+	copy := deepCopySlice(original)
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original[0], copy[0])
+}
+
+func TestDeepCopySliceMixed(t *testing.T) {
+	original := []interface{}{
+		"value1",
+		42,
+		map[string]interface{}{
+			"nestedKey1": "nestedValue1",
+		},
+		[]interface{}{"value2", 43},
+	}
+	copy := deepCopySlice(original)
+	assert.Equal(t, original, copy)
+	assert.NotSame(t, original[2], copy[2])
+	assert.NotSame(t, original[3], copy[3])
+}


### PR DESCRIPTION
The `DeepCopy` method is added to the `JSONObject` struct in order to create a deep copy of the object. This method recursively copies the map and slice elements of the object to ensure that the copied object is independent of the original. This is useful after encountering [this issue](https://github.com/hyperledger/firefly/issues/1310) that occurred because of a shallow copy.

[This code](https://github.com/hyperledger/firefly/pull/1561/files#diff-4e70312913480467cb8f47462da4c1bc568a2d750f22519a1bae78ad41a4b197R106) should call `cop.Input = op.Input.DeepCopy()` once this code is published. 
