### PR TITLE
Route handler to use UseNumber decoding

### DIFF
--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -181,7 +181,9 @@ func (hs *HandlerFactory) RouteHandler(route *Route) http.HandlerFunc {
 				fallthrough
 			case strings.HasPrefix(strings.ToLower(contentType), "application/json"):
 				if jsonInput != nil {
-					err = json.NewDecoder(req.Body).Decode(&jsonInput)
+					d := json.NewDecoder(req.Body)
+					d.UseNumber()
+					err = d.Decode(&jsonInput)
 				}
 			case strings.HasPrefix(strings.ToLower(contentType), "text/plain"):
 			default:


### PR DESCRIPTION
Relates to https://github.com/hyperledger/firefly/issues/1568 and follows on from https://github.com/hyperledger/firefly-common/pull/147.

Like the changes in that PR, this code path also needs to parse large numbers into `json.Number` instead of `float64`.