### PR TITLE
[ffresty] maxIdleConnsPerHost Setting

### DIFF
--- a/pkg/ffresty/config.go
+++ b/pkg/ffresty/config.go
@@ -32,7 +32,8 @@ const (
 	defaultRequestTimeout                = "30s"
 	defaultHTTPIdleTimeout               = "475ms" // Node.js default keepAliveTimeout is 5 seconds, so we have to set a base below this
 	defaultHTTPMaxIdleConns              = 100     // match Go's default
-	defaultHTTPMaxConnsPerHost           = 0
+	defaultHTTPMaxConnsPerHost           = 0       // unlimited
+	defaultHTTPMaxIdleConnsPerHost       = 100     // avoid Go's conservative default of 2, we'd rather it be the same as the maxIdleConns so a single host can use all the connections
 	defaultHTTPConnectionTimeout         = "30s"
 	defaultHTTPTLSHandshakeTimeout       = "10s" // match Go's default
 	defaultHTTPExpectContinueTimeout     = "1s"  // match Go's default
@@ -75,8 +76,11 @@ const (
 	// HTTPThrottleBurst The maximum number of requests that can be made in a short period of time before the RPS throttling kicks in.
 	HTTPThrottleBurst = "throttle.burst"
 
-	// HTTPMaxConnsPerHost the max number of concurrent connections
+	// HTTPMaxConnsPerHost the max number of concurrent connections per host
 	HTTPMaxConnsPerHost = "maxConnsPerHost"
+	// HTTPMaxIdleConnsPerHost the max number of idle connections per host
+	HTTPMaxIdleConnsPerHost = "maxIdleConnsPerHost"
+
 	// HTTPConnectionTimeout the connection timeout for new connections
 	HTTPConnectionTimeout = "connectionTimeout"
 	// HTTPTLSHandshakeTimeout the TLS handshake connection timeout
@@ -107,6 +111,7 @@ func InitConfig(conf config.Section) {
 	conf.AddKnownKey(HTTPIdleTimeout, defaultHTTPIdleTimeout)
 	conf.AddKnownKey(HTTPMaxIdleConns, defaultHTTPMaxIdleConns)
 	conf.AddKnownKey(HTTPMaxConnsPerHost, defaultHTTPMaxConnsPerHost)
+	conf.AddKnownKey(HTTPMaxIdleConnsPerHost, defaultHTTPMaxIdleConnsPerHost)
 	conf.AddKnownKey(HTTPConnectionTimeout, defaultHTTPConnectionTimeout)
 	conf.AddKnownKey(HTTPTLSHandshakeTimeout, defaultHTTPTLSHandshakeTimeout)
 	conf.AddKnownKey(HTTPExpectContinueTimeout, defaultHTTPExpectContinueTimeout)
@@ -135,6 +140,8 @@ func GenerateConfig(ctx context.Context, conf config.Section) (*Config, error) {
 			HTTPRequestTimeout:            fftypes.FFDuration(conf.GetDuration(HTTPConfigRequestTimeout)),
 			HTTPIdleConnTimeout:           fftypes.FFDuration(conf.GetDuration(HTTPIdleTimeout)),
 			HTTPMaxIdleConns:              conf.GetInt(HTTPMaxIdleConns),
+			HTTPMaxConnsPerHost:           conf.GetInt(HTTPMaxConnsPerHost),
+			HTTPMaxIdleConnsPerHost:       conf.GetInt(HTTPMaxIdleConnsPerHost),
 			HTTPConnectionTimeout:         fftypes.FFDuration(conf.GetDuration(HTTPConnectionTimeout)),
 			HTTPTLSHandshakeTimeout:       fftypes.FFDuration(conf.GetDuration(HTTPTLSHandshakeTimeout)),
 			HTTPExpectContinueTimeout:     fftypes.FFDuration(conf.GetDuration(HTTPExpectContinueTimeout)),

--- a/pkg/ffresty/ffresty.go
+++ b/pkg/ffresty/ffresty.go
@@ -80,6 +80,7 @@ type HTTPConfig struct {
 	RetryErrorStatusCodeRegex     string                                    `ffstruct:"RESTConfig" json:"retryErrorStatusCodeRegex,omitempty"`
 	HTTPMaxIdleConns              int                                       `ffstruct:"RESTConfig" json:"maxIdleConns,omitempty"`
 	HTTPMaxConnsPerHost           int                                       `ffstruct:"RESTConfig" json:"maxConnsPerHost,omitempty"`
+	HTTPMaxIdleConnsPerHost       int                                       `ffstruct:"RESTConfig" json:"maxIdleConnsPerHost,omitempty"`
 	HTTPPassthroughHeadersEnabled bool                                      `ffstruct:"RESTConfig" json:"httpPassthroughHeadersEnabled,omitempty"`
 	HTTPHeaders                   fftypes.JSONObject                        `ffstruct:"RESTConfig" json:"headers,omitempty"`
 	HTTPTLSHandshakeTimeout       fftypes.FFDuration                        `ffstruct:"RESTConfig" json:"tlsHandshakeTimeout,omitempty"`
@@ -210,6 +211,7 @@ func NewWithConfig(ctx context.Context, ffrestyConfig Config) (client *resty.Cli
 			ForceAttemptHTTP2:     true,
 			MaxIdleConns:          ffrestyConfig.HTTPMaxIdleConns,
 			MaxConnsPerHost:       ffrestyConfig.HTTPMaxConnsPerHost,
+			MaxIdleConnsPerHost:   ffrestyConfig.HTTPMaxConnsPerHost,
 			IdleConnTimeout:       time.Duration(ffrestyConfig.HTTPIdleConnTimeout),
 			TLSHandshakeTimeout:   time.Duration(ffrestyConfig.HTTPTLSHandshakeTimeout),
 			ExpectContinueTimeout: time.Duration(ffrestyConfig.HTTPExpectContinueTimeout),

--- a/pkg/i18n/en_base_config_descriptions.go
+++ b/pkg/i18n/en_base_config_descriptions.go
@@ -88,6 +88,7 @@ var (
 	ConfigGlobalThrottleBurst             = ffc("config.global.throttle.burst", "The maximum number of requests that can be made in a short period of time before the throttling kicks in.", IntType)
 	ConfigGlobalMaxIdleConns              = ffc("config.global.maxIdleConns", "The max number of idle connections to hold pooled", IntType)
 	ConfigGlobalMaxConnsPerHost           = ffc("config.global.maxConnsPerHost", "The max number of connections, per unique hostname. Zero means no limit", IntType)
+	ConfigGlobalMaxIdleConnsPerHost       = ffc("config.global.maxIdleConnsPerHost", "The max number of idle connections, per unique hostname. Zero means net/http uses the default of only 2.", IntType)
 	ConfigGlobalMethod                    = ffc("config.global.method", "The HTTP method to use when making requests to the Address Resolver", StringType)
 	ConfigGlobalAuthType                  = ffc("config.global.auth.type", "The auth plugin to use for server side authentication of requests", StringType)
 	ConfigGlobalPassthroughHeadersEnabled = ffc("config.global.passthroughHeadersEnabled", "Enable passing through the set of allowed HTTP request headers", BooleanType)

--- a/pkg/i18n/en_base_field_descriptions.go
+++ b/pkg/i18n/en_base_field_descriptions.go
@@ -91,6 +91,7 @@ var (
 	RESTConfigThrottleRequestsPerSecond     = ffm("RESTConfig.requestsPerSecond", "Requests per second")
 	RESTConfigThrottleBurst                 = ffm("RESTConfig.burst", "Burst")
 	RESTConfigMaxConnsPerHost               = ffm("RESTConfig.maxConnsPerHost", "Maximum connections per host")
+	RESTConfigMaxIdleConnsPerHost           = ffm("RESTConfig.maxIdleConnsPerHost", "Maximum idle connections per host")
 	RESTConfigMaxIdleConns                  = ffm("RESTConfig.maxIdleConns", "Maximum idle connections to leave in the connection pool")
 	RESTConfigMaxIdleTimeout                = ffm("RESTConfig.maxIdleTimeout", "Maximum time to leave idle connections in the connection pool")
 	RESTConfigProxyURL                      = ffm("RESTConfig.proxyURL", "URL of a proxy server to use for connections")


### PR DESCRIPTION
Follow's up #153. Reading common performance problems in Go `net/http`, the `maxConnsPerHost` is helpful being unlimited by default but it sounds like the `maxIdleConnsPerHost` will always default to 2 based on the source:
```golang
// DefaultMaxIdleConnsPerHost is the default value of [Transport]'s
// MaxIdleConnsPerHost.
const DefaultMaxIdleConnsPerHost = 2
// ...
type Transport struct {
  // ...
  // MaxIdleConnsPerHost, if non-zero, controls the maximum idle
  // (keep-alive) connections to keep per-host. If zero,
  // DefaultMaxIdleConnsPerHost is used.
  MaxIdleConnsPerHost int
  // ...
}
```

Based on https://stackoverflow.com/a/31810116 and https://www.reddit.com/r/golang/comments/1730po3/comment/k51x8jn/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button we should see our clients default to creating many more connections per host under higher load.