### PR TITLE
[pkg/metric] - Add the ability to register a new metrics collector to the registry

### DIFF
--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -59,7 +59,7 @@ type MetricsRegistry interface {
 	// GetHTTPMetricsInstrumentationsMiddlewareForSubsystem returns the HTTP middleware of a subsystem that used predefined HTTP metrics
 	GetHTTPMetricsInstrumentationsMiddlewareForSubsystem(ctx context.Context, subsystem string) (func(next http.Handler) http.Handler, error)
 
-	RegisterCollector(ctx context.Context, collectors prometheus.Collector)
+	RegisterCollector(ctx context.Context, collector prometheus.Collector)
 }
 
 type FireflyDefaultLabels struct {
@@ -188,6 +188,6 @@ func (pmr *prometheusMetricsRegistry) GetHTTPMetricsInstrumentationsMiddlewareFo
 	return httpInstrumentation.Middleware, nil
 }
 
-func (pmr *prometheusMetricsRegistry) RegisterCollector(ctx context.Context, collectors prometheus.Collector) {
-	pmr.registerer.MustRegister(collectors)
+func (pmr *prometheusMetricsRegistry) RegisterCollector(ctx context.Context, collector prometheus.Collector) {
+	pmr.registerer.MustRegister(collector)
 }

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -58,6 +58,8 @@ type MetricsRegistry interface {
 	NewHTTPMetricsInstrumentationsForSubsystem(ctx context.Context, subsystem string, useRouteTemplate bool, reqDurationBuckets []float64, labels map[string]string) error
 	// GetHTTPMetricsInstrumentationsMiddlewareForSubsystem returns the HTTP middleware of a subsystem that used predefined HTTP metrics
 	GetHTTPMetricsInstrumentationsMiddlewareForSubsystem(ctx context.Context, subsystem string) (func(next http.Handler) http.Handler, error)
+
+	RegisterCollector(ctx context.Context, collectors prometheus.Collector)
 }
 
 type FireflyDefaultLabels struct {
@@ -184,4 +186,8 @@ func (pmr *prometheusMetricsRegistry) GetHTTPMetricsInstrumentationsMiddlewareFo
 		return nil, i18n.NewError(ctx, i18n.MsgMetricsSubsystemHTTPInstrumentationNotFound)
 	}
 	return httpInstrumentation.Middleware, nil
+}
+
+func (pmr *prometheusMetricsRegistry) RegisterCollector(ctx context.Context, collectors prometheus.Collector) {
+	pmr.registerer.MustRegister(collectors)
 }

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -59,7 +59,7 @@ type MetricsRegistry interface {
 	// GetHTTPMetricsInstrumentationsMiddlewareForSubsystem returns the HTTP middleware of a subsystem that used predefined HTTP metrics
 	GetHTTPMetricsInstrumentationsMiddlewareForSubsystem(ctx context.Context, subsystem string) (func(next http.Handler) http.Handler, error)
 
-	MustRegisterCollector(ctx context.Context, collector prometheus.Collector)
+	MustRegisterCollector(collector prometheus.Collector)
 }
 
 type FireflyDefaultLabels struct {
@@ -188,6 +188,6 @@ func (pmr *prometheusMetricsRegistry) GetHTTPMetricsInstrumentationsMiddlewareFo
 	return httpInstrumentation.Middleware, nil
 }
 
-func (pmr *prometheusMetricsRegistry) MustRegisterCollector(ctx context.Context, collector prometheus.Collector) {
+func (pmr *prometheusMetricsRegistry) MustRegisterCollector(collector prometheus.Collector) {
 	pmr.registerer.MustRegister(collector)
 }

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -59,7 +59,7 @@ type MetricsRegistry interface {
 	// GetHTTPMetricsInstrumentationsMiddlewareForSubsystem returns the HTTP middleware of a subsystem that used predefined HTTP metrics
 	GetHTTPMetricsInstrumentationsMiddlewareForSubsystem(ctx context.Context, subsystem string) (func(next http.Handler) http.Handler, error)
 
-	RegisterCollector(ctx context.Context, collector prometheus.Collector)
+	MustRegisterCollector(ctx context.Context, collector prometheus.Collector)
 }
 
 type FireflyDefaultLabels struct {
@@ -188,6 +188,6 @@ func (pmr *prometheusMetricsRegistry) GetHTTPMetricsInstrumentationsMiddlewareFo
 	return httpInstrumentation.Middleware, nil
 }
 
-func (pmr *prometheusMetricsRegistry) RegisterCollector(ctx context.Context, collector prometheus.Collector) {
+func (pmr *prometheusMetricsRegistry) MustRegisterCollector(ctx context.Context, collector prometheus.Collector) {
 	pmr.registerer.MustRegister(collector)
 }


### PR DESCRIPTION
Adding RegisterCollector to support adding a custom prometheus Collector to the prometheus Metrics Registry. Currently `MetricsRegistry` only allows creating a registry with the default GoCollector and ProcessCollector. 