### PR TITLE
[metrics] Configurable Prefix and Avoiding 'ff_' in Tags

### DIFF
--- a/pkg/ffresty/metrics.go
+++ b/pkg/ffresty/metrics.go
@@ -1,0 +1,1 @@
+package ffresty

--- a/pkg/ffresty/metrics.go
+++ b/pkg/ffresty/metrics.go
@@ -1,1 +1,0 @@
-package ffresty

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -94,7 +94,11 @@ type Options struct {
 	MetricsPrefix string
 }
 
-func NewPrometheusMetricsRegistry(componentName string /*component name will be added to all metrics as a label*/, opts *Options) MetricsRegistry {
+func NewPrometheusMetricsRegistry(componentName string /*component name will be added to all metrics as a label*/) MetricsRegistry {
+	return NewPrometheusMetricsRegistryWithOptions(componentName, Options{})
+}
+
+func NewPrometheusMetricsRegistryWithOptions(componentName string /*component name will be added to all metrics as a label*/, opts Options) MetricsRegistry {
 	registry := prometheus.NewRegistry()
 	registerer := prometheus.WrapRegistererWith(prometheus.Labels{compulsoryComponentLabel: componentName}, registry)
 
@@ -103,10 +107,8 @@ func NewPrometheusMetricsRegistry(componentName string /*component name will be 
 	registerer.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 
 	metricsPrefix := ffMetricsPrefix
-	if opts != nil {
-		if opts.MetricsPrefix != "" {
-			metricsPrefix = opts.MetricsPrefix
-		}
+	if opts.MetricsPrefix != "" {
+		metricsPrefix = opts.MetricsPrefix
 	}
 
 	return &prometheusMetricsRegistry{

--- a/pkg/metric/metric_test.go
+++ b/pkg/metric/metric_test.go
@@ -39,6 +39,16 @@ func TestMetricsRegistry(t *testing.T) {
 	assert.NotNil(t, httpHandler)
 }
 
+func TestMetricsRegistryWithOptions(t *testing.T) {
+	mr := NewPrometheusMetricsRegistryWithOptions("test", Options{
+		MetricsPrefix: "foobar",
+	})
+
+	reg := mr.(*prometheusMetricsRegistry)
+
+	assert.Equal(t, "foobar", reg.namespace)
+}
+
 func TestMetricsManager(t *testing.T) {
 	mr := NewPrometheusMetricsRegistry("test")
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Changes

Makes it so the `ff_` prefix on metrics can be replaced with a prefix of the user's choosing via a new optional `Options` struct. And then drops the `ff_` prefix on the metrics label `component` so that it is consistent with other labeling schemes from logs or other metrics libraries, and saves some bytes per metric. Made it so theres a new `New` func for backwards compatibility.

However, having this metric may be redundant bc it can often be inferred from a target's hostname or pod labels. So we should consider dropping, or making the `component` label optional.