### PR TITLE
default monitoring routes

### DIFF
--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -63,6 +63,7 @@ type apiServer[T any] struct {
 	handleYAML                bool
 	monitoringEnabled         bool
 	metricsPath               string
+	monitoringPath            string
 	monitoringPublicURL       string
 	mux                       *mux.Router
 
@@ -102,6 +103,7 @@ func NewAPIServer[T any](ctx context.Context, options APIServerOptions[T]) APISe
 		requestMaxTimeout:         options.APIConfig.GetDuration(ConfAPIRequestMaxTimeout),
 		monitoringEnabled:         options.MonitoringConfig.GetBool(ConfMonitoringServerEnabled),
 		metricsPath:               options.MonitoringConfig.GetString(ConfMonitoringServerMetricsPath),
+		monitoringPath:            options.MonitoringConfig.GetString(ConfMonitoringServerMonitoringPath),
 		alwaysPaginate:            options.APIConfig.GetBool(ConfAPIAlwaysPaginate),
 		handleYAML:                options.HandleYAML,
 		apiDynamicPublicURLHeader: options.APIConfig.GetString(ConfAPIDynamicPublicURLHeader),
@@ -294,6 +296,11 @@ func (as *apiServer[T]) notFoundHandler(res http.ResponseWriter, req *http.Reque
 	return 404, i18n.NewError(req.Context(), i18n.Msg404NotFound)
 }
 
+func (as *apiServer[T]) emptyJSONHandler(res http.ResponseWriter, _ *http.Request) (status int, err error) {
+	res.Header().Add("Content-Type", "application/json")
+	return 200, nil
+}
+
 func (as *apiServer[T]) createMonitoringMuxRouter(ctx context.Context) *mux.Router {
 	r := mux.NewRouter().UseEncodedPath()
 	hf := as.handlerFactory() // TODO separate factory for monitoring ??
@@ -305,9 +312,10 @@ func (as *apiServer[T]) createMonitoringMuxRouter(ctx context.Context) *mux.Rout
 	r.Path(as.metricsPath).Handler(h)
 
 	for _, route := range as.MonitoringRoutes {
-		r.HandleFunc(route.Path, as.routeHandler(hf, route)).Methods(route.Method)
+		r.HandleFunc(fmt.Sprintf("/%s", route.Path), as.routeHandler(hf, route)).Methods(route.Method)
 	}
 
+	r.HandleFunc(as.monitoringPath, hf.APIWrapper(as.emptyJSONHandler))
 	r.NotFoundHandler = hf.APIWrapper(as.notFoundHandler)
 	return r
 }

--- a/pkg/ffapi/apiserver_config.go
+++ b/pkg/ffapi/apiserver_config.go
@@ -22,8 +22,9 @@ import (
 )
 
 var (
-	ConfMonitoringServerEnabled     = "enabled"
-	ConfMonitoringServerMetricsPath = "metricsPath"
+	ConfMonitoringServerEnabled        = "enabled"
+	ConfMonitoringServerMetricsPath    = "metricsPath"
+	ConfMonitoringServerMonitoringPath = "monitoringPath"
 
 	ConfAPIDefaultFilterLimit     = "defaultFilterLimit"
 	ConfAPIMaxFilterLimit         = "maxFilterLimit"
@@ -49,4 +50,5 @@ func InitAPIServerConfig(apiConfig, monitoringConfig, corsConfig config.Section)
 	httpserver.InitHTTPConfig(monitoringConfig, 6000)
 	monitoringConfig.AddKnownKey(ConfMonitoringServerEnabled, true)
 	monitoringConfig.AddKnownKey(ConfMonitoringServerMetricsPath, "/metrics")
+	monitoringConfig.AddKnownKey(ConfMonitoringServerMonitoringPath, "/health")
 }


### PR DESCRIPTION
As a part of the new monitoring server, this PR adds some out of the box routes to this server that can be directly used as liveness and readiness probes for various Kubernetes deployments. Similar to some out of the box routes like `/api` that are provided by the apiServer, the new monitoring server provides a default route `/health`. It is configurable similar to metrics path thus allowing uses to define the path if they wish. This can reduce the duplication effort to add special monitoring routes just for such kubernetes probes. User can still add additional monitoring routes they might want to use through the `MonitoringRoutes` config of the API server.

 