### PR TITLE
[ffapi] Customizing the Subsystem Name to Distinguish Multiple API Server Metrics

### DIFF
--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -71,6 +71,7 @@ type apiServer[T any] struct {
 
 type APIServerOptions[T any] struct {
 	MetricsRegistry           metric.MetricsRegistry
+	MetricsSubsystemName      string
 	Routes                    []*Route
 	MonitoringRoutes          []*Route
 	EnrichRequest             func(r *APIRequest) (T, error)
@@ -114,9 +115,15 @@ func NewAPIServer[T any](ctx context.Context, options APIServerOptions[T]) APISe
 	if as.FavIcon32 == nil {
 		as.FavIcon32 = ffLogo16
 	}
+
+	metricsSubsystemName := APIServerMetricsSubSystemName
+	if options.MetricsSubsystemName != "" {
+		metricsSubsystemName = options.MetricsSubsystemName
+	}
+
 	_ = as.MetricsRegistry.NewHTTPMetricsInstrumentationsForSubsystem(
 		ctx,
-		APIServerMetricsSubSystemName,
+		metricsSubsystemName,
 		true,
 		prometheus.DefBuckets,
 		map[string]string{},


### PR DESCRIPTION
If you have two API servers using ff-common, say one public and one private, they can share a `MetricsRegistry`, and both of their monitoring servers will serve `/metrics` describing them.

However, if those server happen to have similar routes, etc. you cannot distinguish the metrics from the public server vs the private. We re-use the same subsystem name currently, and ignore the error thrown by registering it if its duplicated.

While thats not bad behavior, it'd be great to change the subsystem name so that it could be less verbose and distinguish different API servers i.e. `apiserver` vs `internal_apiserver` or something.

NOTE: doing so does increase the cardinality as thats then two separate timeseries, but thats intentional. We don't use labels either bc users likely want their queries/alerts/dashboards to not risk entangling data from a different API server. We don't need the subsystem name to be configurable via config (though the user could still wire this up this way if they want to) bc metric names should be consistent for a given microservice/project to make it easier for folks to contribute OSS Grafana dashboards, Prometheus alerting rules, etc.