### PR TITLE
[ffapi] [config] application/x-www-form-urlencoded Params and Fixing Usability Bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOGC=30
 .DELETE_ON_ERROR:
 
 all: build test go-mod-tidy
-test: deps
+test: deps lint
 		$(VGO) test ./pkg/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
 coverage.html:
 		$(VGO) tool cover -html=coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOGC=30
 .DELETE_ON_ERROR:
 
 all: build test go-mod-tidy
-test: deps lint
+test: deps
 		$(VGO) test ./pkg/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s
 coverage.html:
 		$(VGO) tool cover -html=coverage.txt

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -162,13 +162,19 @@ func RootConfigReset(setServiceDefaults ...func()) {
 	i18n.SetLang(viper.GetString(string(Lang)))
 }
 
+var envPrefix = "firefly"
+
+func SetEnvPrefix(prefix string) {
+	envPrefix = prefix
+}
+
 // ReadConfig initializes the config
 func ReadConfig(cfgSuffix, cfgFile string) error {
 	keysMutex.Lock() // must only call viper directly here (as we already hold the lock)
 	defer keysMutex.Unlock()
 
 	// Set precedence order for reading config location
-	viper.SetEnvPrefix("firefly")
+	viper.SetEnvPrefix(envPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 	viper.SetConfigType("yaml")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path"
 	"strings"
@@ -490,4 +491,25 @@ func TestConfigWatchE2E(t *testing.T) {
 		<-fsListenerDone
 	}()
 
+}
+
+func TestSetEnvPrefix(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := path.Join(tmpDir, "test.yaml")
+
+	// Create the file
+	os.WriteFile(configPath, []byte(`{"conf": "one"}`), 0664)
+
+	os.Setenv("TEST_UT_CONF", "two")
+	SetEnvPrefix("test")
+
+	RootConfigReset()
+	cfg := RootSection("ut")
+	cfg.AddKnownKey("conf")
+
+	err := ReadConfig("yaml", configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "test", viper.GetViper().GetEnvPrefix())
+
+	assert.Equal(t, "two", cfg.GetString("conf"))
 }

--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -99,6 +99,14 @@ type APIServerRouteExt[T any] struct {
 // NewAPIServer makes a new server, with the specified configuration, and
 // the supplied wrapper function - which will inject
 func NewAPIServer[T any](ctx context.Context, options APIServerOptions[T]) APIServer {
+	if options.APIConfig == nil {
+		panic("APIConfig is required")
+	}
+
+	if options.MonitoringConfig == nil {
+		panic("MonitoringConfig is required")
+	}
+
 	as := &apiServer[T]{
 		defaultFilterLimit:        options.APIConfig.GetUint64(ConfAPIDefaultFilterLimit),
 		maxFilterLimit:            options.APIConfig.GetUint64(ConfAPIMaxFilterLimit),

--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -19,12 +19,13 @@ package ffapi
 import (
 	"context"
 	"fmt"
-	"github.com/hyperledger/firefly-common/pkg/log"
 	"io"
 	"net"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/hyperledger/firefly-common/pkg/log"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -119,19 +119,22 @@ func NewAPIServer[T any](ctx context.Context, options APIServerOptions[T]) APISe
 		as.FavIcon32 = ffLogo16
 	}
 
-	metricsSubsystemName := APIServerMetricsSubSystemName
-	if options.MetricsSubsystemName != "" {
-		metricsSubsystemName = options.MetricsSubsystemName
-	}
-
 	_ = as.MetricsRegistry.NewHTTPMetricsInstrumentationsForSubsystem(
 		ctx,
-		metricsSubsystemName,
+		as.metricsSubsystemName(),
 		true,
 		prometheus.DefBuckets,
 		map[string]string{},
 	)
 	return as
+}
+
+func (as *apiServer[T]) metricsSubsystemName() string {
+	metricsSubsystemName := APIServerMetricsSubSystemName
+	if as.MetricsSubsystemName != "" {
+		metricsSubsystemName = as.MetricsSubsystemName
+	}
+	return metricsSubsystemName
 }
 
 // Can be called before Serve, but MUST use the background context if so
@@ -254,7 +257,7 @@ func (as *apiServer[T]) createMuxRouter(ctx context.Context) *mux.Router {
 	hf := as.handlerFactory()
 
 	if as.monitoringEnabled {
-		h, _ := as.MetricsRegistry.GetHTTPMetricsInstrumentationsMiddlewareForSubsystem(ctx, APIServerMetricsSubSystemName)
+		h, _ := as.MetricsRegistry.GetHTTPMetricsInstrumentationsMiddlewareForSubsystem(ctx, as.metricsSubsystemName())
 		r.Use(h)
 	}
 

--- a/pkg/ffapi/apiserver_test.go
+++ b/pkg/ffapi/apiserver_test.go
@@ -135,10 +135,11 @@ func newTestAPIServer(t *testing.T, start bool) (*utManager, *apiServer[*utManag
 			// request and that's the "T" on the APIServer
 			return um, um.mockEnrichErr
 		},
-		Description:      "unit testing",
-		APIConfig:        apiConfig,
-		MonitoringConfig: monitoringConfig,
-		CORSConfig:       corsConfig,
+		Description:          "unit testing",
+		APIConfig:            apiConfig,
+		MonitoringConfig:     monitoringConfig,
+		CORSConfig:           corsConfig,
+		MetricsSubsystemName: "apiserver_ut",
 	})
 	done := make(chan struct{})
 	if start {

--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -249,11 +249,11 @@ func (hs *HandlerFactory) RouteHandler(route *Route) http.HandlerFunc {
 				r.FP = multipart.formParams
 				r.Part = multipart.part
 				output, err = route.FormUploadHandler(r)
+			case route.StreamHandler != nil:
+				output, err = route.StreamHandler(r)
 			case formParams != nil:
 				r.FP = formParams
 				fallthrough
-			case route.StreamHandler != nil:
-				output, err = route.StreamHandler(r)
 			default:
 				output, err = route.JSONHandler(r)
 			}

--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -71,7 +72,6 @@ type multipartState struct {
 }
 
 func (hs *HandlerFactory) getFilePart(req *http.Request) (*multipartState, error) {
-
 	formParams := make(map[string]string)
 	ctx := req.Context()
 	l := log.L(ctx)
@@ -115,8 +115,7 @@ func (hs *HandlerFactory) getFormParams(req *http.Request) (map[string]string, e
 		}
 
 		if len(v) > 1 {
-			form[k] = strings.Join(v, ",") // TODO is this good enough ?
-			continue
+			return nil, i18n.WrapError(req.Context(), fmt.Errorf("multi-value form parameters for '%s' are not currently supported", k), i18n.MsgParseFormError)
 		}
 
 		form[k] = v[0]

--- a/pkg/ffapi/handler_test.go
+++ b/pkg/ffapi/handler_test.go
@@ -680,3 +680,31 @@ func TestPOSTFormParams(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 201, res.StatusCode)
 }
+
+func TestPOSTFormParamsMultiValueUnsupported(t *testing.T) {
+	s, _, done := newTestServer(t, []*Route{{
+		Name:   "testRoute",
+		Path:   "/test",
+		Method: http.MethodPost,
+		FormParams: []*FormParam{
+			{Name: "foo"},
+		},
+		JSONInputValue:  nil,
+		JSONOutputValue: func() interface{} { return make(map[string]interface{}) },
+		JSONOutputCodes: []int{201},
+		JSONHandler: func(r *APIRequest) (output interface{}, err error) {
+			t.Fail() // we shouldn't get here
+			return map[string]interface{}{}, nil
+		},
+	}}, "/base-path/{param}", []*PathParam{
+		{Name: "param"},
+	})
+	defer done()
+
+	val := url.Values{
+		"foo": {"bar", "foo2"},
+	}
+	res, err := http.PostForm(fmt.Sprintf("http://%s/base-path/baz/test", s.Addr()), val)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, res.StatusCode)
+}

--- a/pkg/ffapi/handler_test.go
+++ b/pkg/ffapi/handler_test.go
@@ -25,6 +25,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -647,6 +648,35 @@ func TestBasePathParameters(t *testing.T) {
 	defer done()
 
 	res, err := http.Get(fmt.Sprintf("http://%s/base-path/foo/test/bar", s.Addr()))
+	assert.NoError(t, err)
+	assert.Equal(t, 201, res.StatusCode)
+}
+
+func TestPOSTFormParams(t *testing.T) {
+	s, _, done := newTestServer(t, []*Route{{
+		Name:   "testRoute",
+		Path:   "/test",
+		Method: http.MethodPost,
+		FormParams: []*FormParam{
+			{Name: "foo"},
+		},
+		JSONInputValue:  nil,
+		JSONOutputValue: func() interface{} { return make(map[string]interface{}) },
+		JSONOutputCodes: []int{201},
+		JSONHandler: func(r *APIRequest) (output interface{}, err error) {
+			assert.Equal(t, "baz", r.PP["param"])
+			assert.Equal(t, "bar", r.FP["foo"])
+			return map[string]interface{}{}, nil
+		},
+	}}, "/base-path/{param}", []*PathParam{
+		{Name: "param"},
+	})
+	defer done()
+
+	val := url.Values{
+		"foo": {"bar"},
+	}
+	res, err := http.PostForm(fmt.Sprintf("http://%s/base-path/baz/test", s.Addr()), val)
 	assert.NoError(t, err)
 	assert.Equal(t, 201, res.StatusCode)
 }

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -265,7 +265,7 @@ func (sg *SwaggerGen) addURLEncodedFormInput(ctx context.Context, op *openapi3.O
 		props[fp.Name] = &openapi3.SchemaRef{
 			Value: &openapi3.Schema{
 				Description: i18n.Expand(ctx, i18n.APISuccessResponse),
-				Type:        "string",
+				Type:        &openapi3.Types{openapi3.TypeString},
 			},
 		}
 	}
@@ -273,7 +273,7 @@ func (sg *SwaggerGen) addURLEncodedFormInput(ctx context.Context, op *openapi3.O
 	op.RequestBody.Value.Content["application/x-www-form-urlencoded"] = &openapi3.MediaType{
 		Schema: &openapi3.SchemaRef{
 			Value: &openapi3.Schema{
-				Type:       "object",
+				Type:       &openapi3.Types{openapi3.TypeObject},
 				Properties: props,
 			},
 		},

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -430,14 +430,15 @@ func (sg *SwaggerGen) addRoute(ctx context.Context, doc *openapi3.T, route *Rout
 	}
 	if route.Method != http.MethodGet && route.Method != http.MethodDelete {
 		sg.initInput(op)
-		if route.FormUploadHandler != nil {
+		switch {
+		case route.FormUploadHandler != nil:
 			// add a mix of JSON and upload form input (though we don't support JSON in the form)
 			sg.addInput(ctx, doc, route, op)
 			sg.addUploadFormInput(ctx, op, route.FormParams)
-		} else if route.FormParams != nil {
+		case route.FormParams != nil:
 			// we only want form input and not JSON input
 			sg.addURLEncodedFormInput(ctx, op, route.FormParams)
-		} else {
+		default:
 			// for all other handlers/inputs just add the standard JSON input
 			sg.addInput(ctx, doc, route, op)
 		}

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -259,7 +259,7 @@ func (sg *SwaggerGen) addUploadFormInput(ctx context.Context, op *openapi3.Opera
 	}
 }
 
-func (sg *SwaggerGen) addUrlEncodedFormInput(ctx context.Context, op *openapi3.Operation, formParams []*FormParam) {
+func (sg *SwaggerGen) addURLEncodedFormInput(ctx context.Context, op *openapi3.Operation, formParams []*FormParam) {
 	props := openapi3.Schemas{}
 	for _, fp := range formParams {
 		props[fp.Name] = &openapi3.SchemaRef{
@@ -430,7 +430,7 @@ func (sg *SwaggerGen) addRoute(ctx context.Context, doc *openapi3.T, route *Rout
 		if route.FormUploadHandler != nil {
 			sg.addUploadFormInput(ctx, op, route.FormParams)
 		} else if route.FormParams != nil {
-			sg.addUrlEncodedFormInput(ctx, op, route.FormParams)
+			sg.addURLEncodedFormInput(ctx, op, route.FormParams)
 		}
 	}
 	sg.addOutput(ctx, doc, route, op)

--- a/pkg/i18n/en_base_error_messages.go
+++ b/pkg/i18n/en_base_error_messages.go
@@ -184,5 +184,5 @@ var (
 	MsgDBErrorBuildingStatement                    = ffe("FF00247", "Error building statement: %s")
 	MsgDBReadInsertTSFailed                        = ffe("FF00248", "Failed to read timestamp from database optimized upsert: %s")
 	MsgUnmarshalToFloat64NotSupported              = ffe("FF00249", "Unmarshalling to a float64 is not supported due to possible precision loss. Consider unmarshalling to an interface, json.Number or fftypes.JSONAny instead")
-	MsgParseFormError                              = ffe("FF00250", "Failed to parse form: %s", http.StatusBadRequest)
+	MsgParseFormError                              = ffe("FF00250", "Failed to parse form", http.StatusBadRequest)
 )

--- a/pkg/i18n/en_base_error_messages.go
+++ b/pkg/i18n/en_base_error_messages.go
@@ -184,4 +184,5 @@ var (
 	MsgDBErrorBuildingStatement                    = ffe("FF00247", "Error building statement: %s")
 	MsgDBReadInsertTSFailed                        = ffe("FF00248", "Failed to read timestamp from database optimized upsert: %s")
 	MsgUnmarshalToFloat64NotSupported              = ffe("FF00249", "Unmarshalling to a float64 is not supported due to possible precision loss. Consider unmarshalling to an interface, json.Number or fftypes.JSONAny instead")
+	MsgParseFormError                              = ffe("FF00250", "Failed to parse form: %s", http.StatusBadRequest)
 )


### PR DESCRIPTION
## Features

* Ability to statically set the env var prefix for the Viper configuration
* `application/x-www-form-urlencoded` support for API route handlers

## Fixes

* Fixes custom subsystem metrics name as a follow up from #170
* Fixes Swagger serving, was broken when we added dynamic header support in https://github.com/hyperledger/firefly-common/pull/97
* Provides error logs if misconfiguring routes w/ `/` path prefix, something we often hit when wiring up API routes in a new project, similar to #169. We want a similar UX / route path expectation when defining routes on the monitoring vs API servers.