### PR TITLE
fix: Schema Type for JSONAny to be an object

### DIFF
--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -201,7 +201,7 @@ func (sg *SwaggerGen) addCustomType(t reflect.Type, schema *openapi3.Schema) {
 	case "FFBigInt":
 		schema.Type = &openapi3.Types{openapi3.TypeString}
 	case "JSONAny":
-		schema.Type = &openapi3.Types{openapi3.TypeString}
+		schema.Type = nil
 	}
 }
 

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -202,6 +202,8 @@ func (sg *SwaggerGen) addCustomType(t reflect.Type, schema *openapi3.Schema) {
 		schema.Type = &openapi3.Types{openapi3.TypeString}
 	case "JSONAny":
 		schema.Type = &openapi3.Types{openapi3.TypeObject}
+		True := true
+		schema.AdditionalProperties = openapi3.AdditionalProperties{Has: &True}
 	}
 }
 

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -206,6 +206,10 @@ func (sg *SwaggerGen) addCustomType(t reflect.Type, schema *openapi3.Schema) {
 		True := true
 		schema.AdditionalProperties = openapi3.AdditionalProperties{Has: &True}
 	}
+
+	if schema.Items != nil && schema.Items.Value != nil {
+		schema.Items.Value.Nullable = false
+	}
 }
 
 func (sg *SwaggerGen) addInput(ctx context.Context, doc *openapi3.T, route *Route, op *openapi3.Operation) {

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -128,7 +128,8 @@ func (sg *SwaggerGen) getPathItem(doc *openapi3.T, path string) *openapi3.PathIt
 func (sg *SwaggerGen) initInput(op *openapi3.Operation) {
 	op.RequestBody = &openapi3.RequestBodyRef{
 		Value: &openapi3.RequestBody{
-			Content: openapi3.Content{},
+			Required: true,
+			Content:  openapi3.Content{},
 		},
 	}
 }

--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -201,7 +201,7 @@ func (sg *SwaggerGen) addCustomType(t reflect.Type, schema *openapi3.Schema) {
 	case "FFBigInt":
 		schema.Type = &openapi3.Types{openapi3.TypeString}
 	case "JSONAny":
-		schema.Type = nil
+		schema.Type = &openapi3.Types{openapi3.TypeObject}
 	}
 }
 


### PR DESCRIPTION
Incorrectly set the schema type of JSONAny to be a string in a previous PR and this sets it to an object 