### PR TITLE
Add support for wrapping an existing WS connection

### DIFF
--- a/pkg/wsclient/wsclient.go
+++ b/pkg/wsclient/wsclient.go
@@ -45,6 +45,7 @@ type WSConfig struct {
 	WriteBufferSize           int                `json:"writeBufferSize,omitempty"`
 	InitialDelay              time.Duration      `json:"initialDelay,omitempty"`
 	MaximumDelay              time.Duration      `json:"maximumDelay,omitempty"`
+	DelayFactor               float64            `json:"delayFactor,omitempty"`
 	InitialConnectAttempts    int                `json:"initialConnectAttempts,omitempty"`
 	DisableReconnect          bool               `json:"disableReconnect"`
 	AuthUsername              string             `json:"authUsername,omitempty"`
@@ -150,6 +151,7 @@ func New(ctx context.Context, config *WSConfig, beforeConnect WSPreConnectHandle
 		connRetry: retry.Retry{
 			InitialDelay: config.InitialDelay,
 			MaximumDelay: config.MaximumDelay,
+			Factor:       config.DelayFactor,
 		},
 		initialRetryAttempts: config.InitialConnectAttempts,
 		headers:              make(http.Header),

--- a/pkg/wsclient/wsconfig.go
+++ b/pkg/wsclient/wsconfig.go
@@ -62,6 +62,11 @@ func InitConfig(conf config.Section) {
 	conf.AddKnownKey(WSConfigURL)
 	conf.AddKnownKey(WSConfigKeyHeartbeatInterval, defaultHeartbeatInterval)
 	conf.AddKnownKey(WSConfigKeyConnectionTimeout, defaultConnectionTimeout)
+	InitConfigWrap(conf)
+}
+
+func InitConfigWrap(conf config.Section) {
+	conf.AddKnownKey(WSConfigKeyHeartbeatInterval, defaultHeartbeatInterval)
 }
 
 func GenerateConfig(ctx context.Context, conf config.Section) (*WSConfig, error) {


### PR DESCRIPTION
The `wsclient` package is very helpful for wrapping a raw websocket connection, with heartbeating, and throttling.

I would like to use it for consistent handling like this of both outbound established connections, and inbound established connections (not using `wsserver` which is too opinionated for me).

This PR allows me to `Wrap()` an existing WebSocket per the demonstration unit test and treat it equivalently to a client connection.

> Also fixed an issue where no backoff factor was being set on the `retry.Retry` for connect retry, meaning the library would fall back to 1 (so no backoff)