### PR TITLE
Add bg WS connect to common utility - superseding initialConnectAttempts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,15 +89,10 @@ type sectionParent interface {
 	AddChild(key string, defValue ...interface{})
 }
 
-type SectionArrayCommon interface {
-	KeySet
-	SubSection(name string) Section
-}
-
 // Section represents a section of the global configuration, at a nested point in the config hierarchy.
 // Note that all keys are added to a GLOBAL map, so this cannot be used for per-instance customization.
 type Section interface {
-	SectionArrayCommon
+	KeySet
 	SetDefault(key string, defValue interface{})
 	SubSection(name string) Section
 	SubArray(name string) ArraySection

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,10 +89,15 @@ type sectionParent interface {
 	AddChild(key string, defValue ...interface{})
 }
 
+type SectionArrayCommon interface {
+	KeySet
+	SubSection(name string) Section
+}
+
 // Section represents a section of the global configuration, at a nested point in the config hierarchy.
 // Note that all keys are added to a GLOBAL map, so this cannot be used for per-instance customization.
 type Section interface {
-	KeySet
+	SectionArrayCommon
 	SetDefault(key string, defValue interface{})
 	SubSection(name string) Section
 	SubArray(name string) ArraySection

--- a/pkg/i18n/en_base_config_descriptions.go
+++ b/pkg/i18n/en_base_config_descriptions.go
@@ -61,6 +61,7 @@ var (
 
 	ConfigGlobalWsConnectionTimeout      = ffc("config.global.ws.connectionTimeout", "The amount of time to wait while establishing a connection (or auto-reconnection)", TimeDurationType)
 	ConfigGlobalWsHeartbeatInterval      = ffc("config.global.ws.heartbeatInterval", "The amount of time to wait between heartbeat signals on the WebSocket connection", TimeDurationType)
+	ConfigGlobalWsBackgroundConnect      = ffc("config.global.ws.backgroundConnect", "When true the connection is established in the background with infinite reconnect (makes initialConnectAttempts redundant when set)", BooleanType)
 	ConfigGlobalWsInitialConnectAttempts = ffc("config.global.ws.initialConnectAttempts", "The number of attempts FireFly will make to connect to the WebSocket when starting up, before failing", IntType)
 	ConfigGlobalWsPath                   = ffc("config.global.ws.path", "The WebSocket sever URL to which FireFly should connect", "WebSocket URL "+StringType)
 	ConfigGlobalWsReadBufferSize         = ffc("config.global.ws.readBufferSize", "The size in bytes of the read buffer for the WebSocket connection", ByteSizeType)

--- a/pkg/wsclient/wsclient_test.go
+++ b/pkg/wsclient/wsclient_test.go
@@ -130,7 +130,7 @@ func TestWSClientE2ETLS(t *testing.T) {
 
 }
 
-func TestWSClientE2E(t *testing.T) {
+func TestWSClientE2EBG(t *testing.T) {
 
 	toServer, fromServer, url, close := NewTestWSServer(func(req *http.Request) {
 		assert.Equal(t, "/test/updated", req.URL.Path)
@@ -155,7 +155,7 @@ func TestWSClientE2E(t *testing.T) {
 	wsConfig.HTTPURL = url
 	wsConfig.WSKeyPath = "/test"
 	wsConfig.HeartbeatInterval = 50 * time.Millisecond
-	wsConfig.InitialConnectAttempts = 2
+	wsConfig.BackgroundConnect = true
 
 	wsc, err := New(context.Background(), wsConfig, beforeConnect, afterConnect)
 	assert.NoError(t, err)
@@ -259,6 +259,21 @@ func TestWSClientE2EReceiveExt(t *testing.T) {
 	// Close the client
 	wsc.Close()
 
+}
+
+func TestWSNeverConnectBG(t *testing.T) {
+	closedSvr := httptest.NewServer(&http.ServeMux{})
+	closedSvr.Close()
+
+	wsc, err := New(context.Background(), &WSConfig{
+		HTTPURL:           closedSvr.URL,
+		BackgroundConnect: true,
+	}, nil, nil)
+	assert.NoError(t, err)
+	err = wsc.Connect()
+	assert.NoError(t, err)
+
+	wsc.Close()
 }
 
 func TestWSClientBadWSURL(t *testing.T) {

--- a/pkg/wsclient/wsconfig.go
+++ b/pkg/wsclient/wsconfig.go
@@ -94,6 +94,7 @@ func GenerateConfig(ctx context.Context, conf config.Section) (*WSConfig, error)
 		MaximumDelay:           conf.GetDuration(ffresty.HTTPConfigRetryMaxDelay),
 		DelayFactor:            conf.GetFloat64(WSConfigDelayFactor),
 		InitialConnectAttempts: conf.GetInt(WSConfigKeyInitialConnectAttempts),
+		BackgroundConnect:      conf.GetBool(WSConfigKeyBackgroundConnect),
 		HTTPHeaders:            conf.GetObject(ffresty.HTTPConfigHeaders),
 		AuthUsername:           conf.GetString(ffresty.HTTPConfigAuthUsername),
 		AuthPassword:           conf.GetString(ffresty.HTTPConfigAuthPassword),

--- a/pkg/wsclient/wsconfig.go
+++ b/pkg/wsclient/wsconfig.go
@@ -42,6 +42,8 @@ const (
 	WSConfigKeyReadBufferSize = "ws.readBufferSize"
 	// WSConfigKeyInitialConnectAttempts sets how many times the websocket should attempt to connect on startup, before failing (after initial connection, retry is indefinite)
 	WSConfigKeyInitialConnectAttempts = "ws.initialConnectAttempts"
+	// WSConfigKeyBackgroundConnect is recommended instead of initialConnectAttempts for new uses of this library, and makes initial connection and reconnection identical in behavior
+	WSConfigKeyBackgroundConnect = "ws.backgroundConnect"
 	// WSConfigKeyPath if set will define the path to connect to - allows sharing of the same URL between HTTP and WebSocket connection info
 	WSConfigKeyPath = "ws.path"
 	// WSConfigURL if set will be a completely separate URL for WebSockets (must be a ws: or wss: scheme)
@@ -60,7 +62,15 @@ func InitConfig(conf config.Section) {
 	ffresty.InitConfig(conf)
 	conf.AddKnownKey(WSConfigKeyWriteBufferSize, defaultBufferSize)
 	conf.AddKnownKey(WSConfigKeyReadBufferSize, defaultBufferSize)
+
+	// Note that conf.SetDefault(WSConfigKeyBackgroundConnect, true) is recommended for implementations
+	// that embed this library, which will cause continual exponential backoff retry connection
+	// even on the initial connection.
+	conf.AddKnownKey(WSConfigKeyBackgroundConnect, false)
+
+	// Ignored if WSConfigKeyBackgroundConnect is true
 	conf.AddKnownKey(WSConfigKeyInitialConnectAttempts, defaultInitialConnectAttempts)
+
 	conf.AddKnownKey(WSConfigKeyPath)
 	conf.AddKnownKey(WSConfigURL)
 	conf.AddKnownKey(WSConfigKeyHeartbeatInterval, defaultHeartbeatInterval)

--- a/pkg/wsclient/wsconfig_test.go
+++ b/pkg/wsclient/wsconfig_test.go
@@ -33,6 +33,8 @@ func TestWSConfigGeneration(t *testing.T) {
 	utConf.Set(WSConfigKeyWriteBufferSize, 1024)
 	utConf.Set(WSConfigKeyInitialConnectAttempts, 1)
 	utConf.Set(WSConfigKeyPath, "/websocket")
+	utConf.Set(WSConfigKeyBackgroundConnect, true)
+	utConf.Set(WSConfigKeyHeartbeatInterval, "42ms")
 
 	ctx := context.Background()
 	wsConfig, err := GenerateConfig(ctx, utConf)
@@ -48,6 +50,20 @@ func TestWSConfigGeneration(t *testing.T) {
 	assert.Equal(t, "custom value", wsConfig.HTTPHeaders.GetString("custom-header"))
 	assert.Equal(t, 1024, wsConfig.ReadBufferSize)
 	assert.Equal(t, 1024, wsConfig.WriteBufferSize)
+	assert.True(t, wsConfig.BackgroundConnect)
+	assert.Equal(t, 42*time.Millisecond, wsConfig.HeartbeatInterval)
+}
+
+func TestWSConfigGenerationDefaults(t *testing.T) {
+	resetConf()
+
+	ctx := context.Background()
+	wsConfig, err := GenerateConfig(ctx, utConf)
+	assert.NoError(t, err)
+
+	assert.Equal(t, defaultInitialConnectAttempts, wsConfig.InitialConnectAttempts)
+	assert.False(t, wsConfig.BackgroundConnect)
+	assert.Equal(t, 30*time.Second, wsConfig.HeartbeatInterval)
 }
 
 func TestWSConfigTLSGenerationFail(t *testing.T) {


### PR DESCRIPTION
The journey (multiple hops) that lead to https://github.com/hyperledger/firefly/pull/1315 told us that `initialConnectAttempts` was a bit of a flawed coupling strategy between asynchronously starting microservices.

We abandoned it, but left the feature in the common library without a clue that it was flawed.

So this PR tries to help other users like me from repeating the mistake :)