### PR TITLE
Add ability to dynamically add filter JSON fields (and test coverage)

### DIFF
--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -386,9 +386,8 @@ func (as *apiServer[T]) notFoundHandler(res http.ResponseWriter, req *http.Reque
 	return 404, i18n.NewError(req.Context(), i18n.Msg404NotFound)
 }
 
-func (as *apiServer[T]) emptyJSONHandler(res http.ResponseWriter, _ *http.Request) (status int, err error) {
-	res.Header().Add("Content-Type", "application/json")
-	return 200, nil
+func (as *apiServer[T]) noContentResponder(res http.ResponseWriter, _ *http.Request) {
+	res.WriteHeader(http.StatusNoContent)
 }
 
 func (as *apiServer[T]) createMonitoringMuxRouter(ctx context.Context) (*mux.Router, error) {
@@ -400,7 +399,7 @@ func (as *apiServer[T]) createMonitoringMuxRouter(ctx context.Context) (*mux.Rou
 		panic(err)
 	}
 	r.Path(as.metricsPath).Handler(h)
-	r.HandleFunc(as.livenessPath, hf.APIWrapper(as.emptyJSONHandler))
+	r.HandleFunc(as.livenessPath, as.noContentResponder)
 
 	for _, route := range as.MonitoringRoutes {
 		path := route.Path

--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -202,7 +202,7 @@ func (as *apiServer[T]) Serve(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-		as.monitoringPublicURL = buildPublicURL(as.MonitoringConfig, apiHTTPServer.Addr())
+		as.monitoringPublicURL = buildPublicURL(as.MonitoringConfig, monitoringHTTPServer.Addr())
 		go monitoringHTTPServer.ServeHTTP(ctx)
 	}
 
@@ -217,6 +217,10 @@ func (as *apiServer[T]) Started() <-chan struct{} {
 
 func (as *apiServer[T]) APIPublicURL() string {
 	return as.apiPublicURL
+}
+
+func (as *apiServer[T]) MonitoringPublicURL() string {
+	return as.monitoringPublicURL
 }
 
 func (as *apiServer[T]) waitForServerStop(httpErrChan, monitoringErrChan chan error) error {

--- a/pkg/ffapi/apiserver_test.go
+++ b/pkg/ffapi/apiserver_test.go
@@ -232,7 +232,7 @@ func TestAPIServerInvokeAPIRouteLiveness(t *testing.T) {
 
 	res, err := resty.New().R().Get(fmt.Sprintf("%s/livez", as.MonitoringPublicURL()))
 	assert.NoError(t, err)
-	assert.Equal(t, 200, res.StatusCode()) // note this should really be 204, but not changing as would change behavior
+	assert.Equal(t, 204, res.StatusCode())
 }
 
 func TestAPIServerPanicsMisConfig(t *testing.T) {

--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -216,7 +216,9 @@ func (hs *HandlerFactory) RouteHandler(route *Route) http.HandlerFunc {
 				req.Header.Set("Content-Type", "application/json; charset=utf8")
 				fallthrough
 			case strings.HasPrefix(strings.ToLower(contentType), "application/json"):
-				if jsonInput != nil {
+				if route.JSONInputDecoder != nil {
+					jsonInput, err = route.JSONInputDecoder(req, req.Body)
+				} else if jsonInput != nil {
 					d := json.NewDecoder(req.Body)
 					d.UseNumber()
 					err = d.Decode(&jsonInput)

--- a/pkg/ffapi/openapi3_test.go
+++ b/pkg/ffapi/openapi3_test.go
@@ -178,6 +178,21 @@ var testRoutes = []*Route{
 		JSONOutputValue: func() interface{} { return &TestStruct1{} },
 		JSONOutputCodes: []int{http.StatusOK},
 	},
+	{
+		Name:            "op7",
+		Path:            "example7",
+		Method:          http.MethodPut,
+		PathParams:      nil,
+		QueryParams:     nil,
+		Description:     ExampleDesc,
+		JSONInputValue:  func() interface{} { return &TestStruct1{} },
+		JSONOutputValue: func() interface{} { return nil },
+		JSONOutputCodes: []int{http.StatusNoContent},
+		FormParams: []*FormParam{
+			{Name: "metadata", Description: ExampleDesc},
+		},
+		Tag: example2TagName,
+	},
 }
 
 type TestInOutType struct {

--- a/pkg/ffapi/openapihandler.go
+++ b/pkg/ffapi/openapihandler.go
@@ -95,10 +95,6 @@ func (ohf *OpenAPIHandlerFactory) getPublicURL(req *http.Request, relativePath s
 	if publicURL == "" {
 		publicURL = ohf.StaticPublicURL
 	}
-	if publicURL == "" {
-		// Do not recommend this fallback - StaticPublicURL and/or DynamicPublicURLHeader should be set
-		publicURL = fmt.Sprintf("https://%s", req.Host)
-	}
 	publicURL = strings.TrimSuffix(publicURL, "/")
 	if len(relativePath) > 0 {
 		publicURL = publicURL + "/" + strings.TrimPrefix(relativePath, "/")

--- a/pkg/ffapi/query_fields.go
+++ b/pkg/ffapi/query_fields.go
@@ -38,12 +38,6 @@ type QueryFactory interface {
 	NewFilter(ctx context.Context) FilterBuilder
 	NewFilterLimit(ctx context.Context, defLimit uint64) FilterBuilder
 	NewUpdate(ctx context.Context) UpdateBuilder
-	Clone() ClonedQueryFactory
-}
-
-type ClonedQueryFactory interface {
-	QueryFactory
-	AddField(n string, f Field)
 }
 
 type FieldMod int
@@ -78,11 +72,7 @@ func (qf QueryFields) NewUpdate(ctx context.Context) UpdateBuilder {
 	}
 }
 
-func (qf QueryFields) AddField(n string, f Field) {
-	qf[n] = f
-}
-
-func (qf QueryFields) Clone() ClonedQueryFactory {
+func (qf QueryFields) Clone() QueryFields {
 	qf2 := make(QueryFields, len(qf))
 	for n, f := range qf {
 		qf2[n] = f

--- a/pkg/ffapi/query_fields.go
+++ b/pkg/ffapi/query_fields.go
@@ -38,6 +38,12 @@ type QueryFactory interface {
 	NewFilter(ctx context.Context) FilterBuilder
 	NewFilterLimit(ctx context.Context, defLimit uint64) FilterBuilder
 	NewUpdate(ctx context.Context) UpdateBuilder
+	Clone() ClonedQueryFactory
+}
+
+type ClonedQueryFactory interface {
+	QueryFactory
+	AddField(n string, f Field)
 }
 
 type FieldMod int
@@ -53,23 +59,35 @@ type HasFieldMods interface {
 
 type QueryFields map[string]Field
 
-func (qf *QueryFields) NewFilterLimit(ctx context.Context, defLimit uint64) FilterBuilder {
+func (qf QueryFields) NewFilterLimit(ctx context.Context, defLimit uint64) FilterBuilder {
 	return &filterBuilder{
 		ctx:         ctx,
-		queryFields: *qf,
+		queryFields: qf,
 		limit:       defLimit,
 	}
 }
 
-func (qf *QueryFields) NewFilter(ctx context.Context) FilterBuilder {
+func (qf QueryFields) NewFilter(ctx context.Context) FilterBuilder {
 	return qf.NewFilterLimit(ctx, 0)
 }
 
-func (qf *QueryFields) NewUpdate(ctx context.Context) UpdateBuilder {
+func (qf QueryFields) NewUpdate(ctx context.Context) UpdateBuilder {
 	return &updateBuilder{
 		ctx:         ctx,
-		queryFields: *qf,
+		queryFields: qf,
 	}
+}
+
+func (qf QueryFields) AddField(n string, f Field) {
+	qf[n] = f
+}
+
+func (qf QueryFields) Clone() ClonedQueryFactory {
+	qf2 := make(QueryFields, len(qf))
+	for n, f := range qf {
+		qf2[n] = f
+	}
+	return qf2
 }
 
 // FieldSerialization - we stand on the shoulders of the well adopted SQL serialization interface here to help us define what
@@ -284,17 +302,11 @@ func (f *bigIntField) Scan(src interface{}) (err error) {
 	case int64:
 		f.i = fftypes.NewFFBigInt(tv)
 	case uint:
-		if tv > math.MaxInt64 {
-			return i18n.NewError(context.Background(), i18n.MsgTypeRestoreFailed, src, f.i)
-		}
-		f.i = fftypes.NewFFBigInt(int64(tv))
+		f.i = (*fftypes.FFBigInt)(new(big.Int).SetUint64(uint64(tv)))
 	case uint32:
 		f.i = fftypes.NewFFBigInt(int64(tv))
 	case uint64:
-		if tv > math.MaxInt64 {
-			return i18n.NewError(context.Background(), i18n.MsgTypeRestoreFailed, src, f.i)
-		}
-		f.i = fftypes.NewFFBigInt(int64(tv))
+		f.i = (*fftypes.FFBigInt)(new(big.Int).SetUint64(tv))
 	case fftypes.FFBigInt:
 		i := tv
 		f.i = &i

--- a/pkg/ffapi/query_fields_test.go
+++ b/pkg/ffapi/query_fields_test.go
@@ -17,6 +17,8 @@
 package ffapi
 
 import (
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -137,6 +139,15 @@ func TestInt64Field(t *testing.T) {
 	v, err = f.Value()
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), v)
+
+	err = f.Scan(uint64(math.MaxInt64 + 1))
+	assert.Regexp(t, "FF00105", err)
+
+	err = f.Scan(uint(math.MaxInt64 + 1))
+	assert.Regexp(t, "FF00105", err)
+
+	err = f.Scan(fmt.Sprintf("%d", uint64(math.MaxInt64+1)))
+	assert.Regexp(t, "FF00105", err)
 
 }
 

--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -178,8 +178,19 @@ func (jq *QueryJSON) BuildFilter(ctx context.Context, qf QueryFactory, options .
 	if jq.Limit != nil {
 		fb = fb.Limit(*jq.Limit)
 	}
-	for _, s := range jq.Sort {
-		fb = fb.Sort(s)
+	if len(jq.Sort) > 0 {
+		rv := buildResolveCtx(ctx, &jq.FilterJSON, options...)
+		for _, field := range jq.Sort {
+			field, isDesc := strings.CutPrefix(field, "-")
+			field, err := validateFilterField(ctx, fb, field, rv)
+			if err != nil {
+				return nil, err
+			}
+			if isDesc {
+				field = "-" + field
+			}
+			fb = fb.Sort(field)
+		}
 	}
 	return (&jq.FilterJSON).BuildSubFilter(ctx, fb, options...)
 }

--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -77,6 +77,7 @@ type FilterJSONOps struct {
 	NEq                []*FilterJSONKeyValue  `ffstruct:"FilterJSON" json:"neq,omitempty"` // negated short name
 	Contains           []*FilterJSONKeyValue  `ffstruct:"FilterJSON" json:"contains,omitempty"`
 	StartsWith         []*FilterJSONKeyValue  `ffstruct:"FilterJSON" json:"startsWith,omitempty"`
+	EndsWith           []*FilterJSONKeyValue  `ffstruct:"FilterJSON" json:"endsWith,omitempty"`
 	LessThan           []*FilterJSONKeyValue  `ffstruct:"FilterJSON" json:"lessThan,omitempty"`
 	LT                 []*FilterJSONKeyValue  `ffstruct:"FilterJSON" json:"lt,omitempty"` // short name
 	LessThanOrEqual    []*FilterJSONKeyValue  `ffstruct:"FilterJSON" json:"lessThanOrEqual,omitempty"`
@@ -253,6 +254,25 @@ func (jf *FilterJSON) addSimpleFilters(ctx context.Context, fb FilterBuilder, an
 				andFilter = andFilter.Condition(fb.NotStartsWith(field, rv.resolve(field, e.Value.String())))
 			} else {
 				andFilter = andFilter.Condition(fb.StartsWith(field, rv.resolve(field, e.Value.String())))
+			}
+		}
+	}
+	for _, e := range jf.EndsWith {
+		field, err := validateFilterField(ctx, fb, e.Field, rv)
+		if err != nil {
+			return nil, err
+		}
+		if e.CaseInsensitive {
+			if e.Not {
+				andFilter = andFilter.Condition(fb.NotIEndsWith(field, rv.resolve(field, e.Value.String())))
+			} else {
+				andFilter = andFilter.Condition(fb.IEndsWith(field, rv.resolve(field, e.Value.String())))
+			}
+		} else {
+			if e.Not {
+				andFilter = andFilter.Condition(fb.NotEndsWith(field, rv.resolve(field, e.Value.String())))
+			} else {
+				andFilter = andFilter.Condition(fb.EndsWith(field, rv.resolve(field, e.Value.String())))
 			}
 		}
 	}

--- a/pkg/ffapi/restfilter_json_test.go
+++ b/pkg/ffapi/restfilter_json_test.go
@@ -359,6 +359,46 @@ func TestBuildQueryJSONStartsWith(t *testing.T) {
 	assert.Equal(t, "( tag ^= '0' ) && ( tag !^ 'abc' ) && ( tag :^ 'ABC' ) && ( tag ;^ 'true' ) skip=5 limit=10", fi.String())
 }
 
+func TestBuildQueryJSONEndsWith(t *testing.T) {
+
+	var qf QueryJSON
+	err := json.Unmarshal([]byte(`{
+		"skip": 5,
+		"limit": 10,
+		"endsWith": [
+			{
+				"field": "tag",
+				"value": 0
+			},
+			{
+				"not": true,
+				"field": "tag",
+				"value": "abc"
+			},
+			{
+				"caseInsensitive": true,
+				"field": "tag",
+				"value": "ABC"
+			},
+			{
+				"caseInsensitive": true,
+				"not": true,
+				"field": "tag",
+				"value": true
+			}
+		]
+	}`), &qf)
+	assert.NoError(t, err)
+
+	filter, err := qf.BuildFilter(context.Background(), TestQueryFactory)
+	assert.NoError(t, err)
+
+	fi, err := filter.Finalize()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "( tag $= '0' ) && ( tag !$ 'abc' ) && ( tag :$ 'ABC' ) && ( tag ;$ 'true' ) skip=5 limit=10", fi.String())
+}
+
 func TestBuildQueryJSONGreaterThan(t *testing.T) {
 
 	var qf QueryJSON
@@ -556,39 +596,45 @@ func TestBuildQueryJSONBadFields(t *testing.T) {
 	assert.Regexp(t, "FF00142", err)
 
 	var qf4 QueryJSON
-	err = json.Unmarshal([]byte(`{"lessThan": [{"field": "wrong"}]}`), &qf4)
+	err = json.Unmarshal([]byte(`{"endsWith": [{"field": "wrong"}]}`), &qf4)
 	assert.NoError(t, err)
 	_, err = qf4.BuildFilter(context.Background(), TestQueryFactory)
 	assert.Regexp(t, "FF00142", err)
 
 	var qf5 QueryJSON
-	err = json.Unmarshal([]byte(`{"lessThanOrEqual": [{"field": "wrong"}]}`), &qf5)
+	err = json.Unmarshal([]byte(`{"lessThan": [{"field": "wrong"}]}`), &qf5)
 	assert.NoError(t, err)
 	_, err = qf5.BuildFilter(context.Background(), TestQueryFactory)
 	assert.Regexp(t, "FF00142", err)
 
 	var qf6 QueryJSON
-	err = json.Unmarshal([]byte(`{"greaterThan": [{"field": "wrong"}]}`), &qf6)
+	err = json.Unmarshal([]byte(`{"lessThanOrEqual": [{"field": "wrong"}]}`), &qf6)
 	assert.NoError(t, err)
 	_, err = qf6.BuildFilter(context.Background(), TestQueryFactory)
 	assert.Regexp(t, "FF00142", err)
 
 	var qf7 QueryJSON
-	err = json.Unmarshal([]byte(`{"greaterThanOrEqual": [{"field": "wrong"}]}`), &qf7)
+	err = json.Unmarshal([]byte(`{"greaterThan": [{"field": "wrong"}]}`), &qf7)
 	assert.NoError(t, err)
 	_, err = qf7.BuildFilter(context.Background(), TestQueryFactory)
 	assert.Regexp(t, "FF00142", err)
 
 	var qf8 QueryJSON
-	err = json.Unmarshal([]byte(`{"in": [{"field": "wrong"}]}`), &qf8)
+	err = json.Unmarshal([]byte(`{"greaterThanOrEqual": [{"field": "wrong"}]}`), &qf8)
 	assert.NoError(t, err)
 	_, err = qf8.BuildFilter(context.Background(), TestQueryFactory)
 	assert.Regexp(t, "FF00142", err)
 
 	var qf9 QueryJSON
-	err = json.Unmarshal([]byte(`{"null": [{"field": "wrong"}]}`), &qf9)
+	err = json.Unmarshal([]byte(`{"in": [{"field": "wrong"}]}`), &qf9)
 	assert.NoError(t, err)
 	_, err = qf9.BuildFilter(context.Background(), TestQueryFactory)
+	assert.Regexp(t, "FF00142", err)
+
+	var qf10 QueryJSON
+	err = json.Unmarshal([]byte(`{"null": [{"field": "wrong"}]}`), &qf10)
+	assert.NoError(t, err)
+	_, err = qf10.BuildFilter(context.Background(), TestQueryFactory)
 	assert.Regexp(t, "FF00142", err)
 }
 

--- a/pkg/ffapi/restfilter_json_test.go
+++ b/pkg/ffapi/restfilter_json_test.go
@@ -184,7 +184,7 @@ func TestBuildQuerySingleNestedWithResolverOk(t *testing.T) {
 	filter, err := qf.BuildFilter(context.Background(), tqf,
 		FieldResolver(func(ctx context.Context, fieldName string) (resolvedFieldName string, err error) {
 			resolvedFieldName = fieldName + ".resolved"
-			tqf.AddField(resolvedFieldName, &StringField{})
+			tqf[resolvedFieldName] = &StringField{}
 			return
 		}),
 		ValueResolver(func(ctx context.Context, level *FilterJSON, fieldName, suppliedValue string) (driver.Value, error) {

--- a/pkg/ffapi/routes.go
+++ b/pkg/ffapi/routes.go
@@ -19,6 +19,7 @@ package ffapi
 import (
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/hyperledger/firefly-common/pkg/config"
@@ -52,6 +53,8 @@ type Route struct {
 	PreTranslatedDescription string
 	// FilterFactory models the filter fields that can be specified on the API, and will automatically be parsed
 	FilterFactory QueryFactory
+	// JSONInputDecoder is a function that does the decoding completely - needed (as this was written pre-generics) for handling arrays
+	JSONInputDecoder func(req *http.Request, body io.Reader) (interface{}, error)
 	// JSONInputValue is a function that returns a pointer to a structure to take JSON input
 	JSONInputValue func() interface{}
 	// JSONInputMask are fields that aren't available for users to supply on input

--- a/pkg/i18n/en_base_field_descriptions.go
+++ b/pkg/i18n/en_base_field_descriptions.go
@@ -27,6 +27,7 @@ var (
 	FilterJSONEq                 = ffm("FilterJSON.eq", "Shortname for equal")
 	FilterJSONNEq                = ffm("FilterJSON.neq", "Shortcut for equal with all conditions negated (the not property of all children is overridden)")
 	FilterJSONStartsWith         = ffm("FilterJSON.startsWith", "Array of field + value combinations to apply as starts-with filters - all filters must match")
+	FilterJSONEndsWith           = ffm("FilterJSON.endsWith", "Array of field + value combinations to apply as ends-with filters - all filters must match")
 	FilterJSONGreaterThan        = ffm("FilterJSON.greaterThan", "Array of field + value combinations to apply as greater-than filters - all filters must match")
 	FilterJSONGT                 = ffm("FilterJSON.gt", "Short name for greaterThan")
 	FilterJSONGreaterThanOrEqual = ffm("FilterJSON.greaterThanOrEqual", "Array of field + value combinations to apply as greater-than filters - all filters must match")

--- a/pkg/wsclient/wsclient.go
+++ b/pkg/wsclient/wsclient.go
@@ -307,6 +307,10 @@ func (w *wsClient) Send(ctx context.Context, message []byte) error {
 		return nil
 	case <-ctx.Done():
 		return i18n.NewError(ctx, i18n.MsgWSSendTimedOut)
+	case <-w.sendDone:
+		// Need this case because the receiver can actually call the sender indirectly on reconnect,
+		// so if the sender loop fails the receiver can get blocked
+		return i18n.NewError(ctx, i18n.MsgWSClosing)
 	case <-w.closing:
 		return i18n.NewError(ctx, i18n.MsgWSClosing)
 	}

--- a/pkg/wsclient/wsclient_test.go
+++ b/pkg/wsclient/wsclient_test.go
@@ -394,6 +394,18 @@ func TestWSSendCanceledContext(t *testing.T) {
 	assert.Regexp(t, "FF00146", err)
 }
 
+func TestWSSenderClosed(t *testing.T) {
+
+	w := &wsClient{
+		send:     make(chan []byte),
+		sendDone: make(chan []byte),
+	}
+	close(w.sendDone)
+
+	err := w.Send(context.Background(), []byte(`sent after close`))
+	assert.Regexp(t, "FF00147", err)
+}
+
 func TestWSConnectClosed(t *testing.T) {
 
 	w := &wsClient{


### PR DESCRIPTION
When processing a `JSONQuery` filter it is helpful to be able to dynamically build up a list of fields, for cases where there might be join tables to something very dynamic like a set of `tags`/`labels` that require an individual join for each filterable tag.

- Added `FieldResolver` plug extension following the existing plugin pattern for `ValueResolver`
- Allowed a `Clone()` of a field set, to a new map that lets to add fields
   - As per the included test you need to update this dynamically so the `Finalize()` will work
- `endsWith` had been omitted form JSON Query - so added that

## Additional things found

- We couldn't support array typed input on the `JSONHandler` due to a quirk where the type was ending up as `[]interface{}` rather than the type returned from `JSONInputValue`. I've proposed a new `JSONInputDecoder` for that, which lets you work around this very simply:
    - https://github.com/hyperledger/firefly-common/blob/fcaa664b46cd6d77936a1179e29524545431878e/pkg/ffapi/apiserver_test.go#L125-L129
- There was some invalid code in the filter logic around BigInt processing that I fixed writing missing tests - it was discarding numbers that are perfectly acceptable for big integer filters. Unlikely to have been used, but I think this was a copy/paste from the other code to make a compiler check on integer limits go away.
- Found some untested code around versions and OpenAPI constructs and validated it executed as written
- I was wondering about the `200` rather than `204` return code that was specified in the liveness check, which returns a `Content-Type: application/json` without any body. But I just commented that rather than changing it. 
    - Not sure if @onelapahead has a thought there... I was worried about changing it (doesn't block merging)