### PR TITLE
Fix IsSet() function for sub-sections

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -638,7 +638,7 @@ func (c *configSection) IsSet(key string) bool {
 	keysMutex.Lock()
 	defer keysMutex.Unlock()
 
-	return viper.IsSet(key)
+	return viper.IsSet(c.prefixKey(key))
 }
 
 // SetupLogging initializes logging

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,12 +19,13 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
@@ -86,10 +87,18 @@ func TestDefaults(t *testing.T) {
 
 func TestValueSet(t *testing.T) {
 	RootConfigReset()
+
 	// keys with default values are not set
+	AddRootKey("key1")
 	assert.False(t, IsSet("key1"))
 	Set("key1", "updatedvalue")
 	assert.True(t, IsSet("key1"))
+
+	section := RootSection("child")
+	section.AddKnownKey("key1")
+	assert.False(t, section.IsSet("key1"))
+	section.Set("key1", "updatedvalue")
+	assert.True(t, section.IsSet("key1"))
 }
 
 func TestSpecificConfigFileOk(t *testing.T) {


### PR DESCRIPTION
Unit test shows the failing case and the fix.

Noticed this adding a missing test for this code, which I believe is broken:
https://github.com/hyperledger/firefly-evmconnect/blob/f0495f96f2c7517c62434bdef81d4b67289bbb7e/internal/ethereum/ethereum.go#L73-L77