### PR TITLE
Add ability to explicitly set a field to NULL

### DIFF
--- a/pkg/dbsql/filter_sql.go
+++ b/pkg/dbsql/filter_sql.go
@@ -175,8 +175,11 @@ func (s *Database) BuildUpdate(sel sq.UpdateBuilder, update ffapi.Update, typeMa
 		return sel, err
 	}
 	for _, so := range ui.SetOperations {
-
-		sel = sel.Set(s.mapFieldName("", so.Field, typeMap), so.Value)
+		if ffapi.IsNull(so.Value) {
+			sel = sel.Set(s.mapFieldName("", so.Field, typeMap), sq.Expr("NULL"))
+		} else {
+			sel = sel.Set(s.mapFieldName("", so.Field, typeMap), so.Value)
+		}
 	}
 	return sel, nil
 }

--- a/pkg/dbsql/filter_sql_test.go
+++ b/pkg/dbsql/filter_sql_test.go
@@ -365,6 +365,20 @@ func TestBuildUpdateExample(t *testing.T) {
 	assert.Equal(t, "tag1", v)
 }
 
+func TestBuildUpdateSetNull(t *testing.T) {
+
+	s, _ := NewMockProvider().UTInit()
+	ub := TestQueryFactory.NewUpdate(context.Background())
+	q := squirrel.Update("table1")
+	updateQuery, err := s.BuildUpdate(q, ub.SetNull("tag"), nil)
+	assert.NoError(t, err)
+
+	sqlFilter, args, err := updateQuery.ToSql()
+	assert.NoError(t, err)
+	assert.Equal(t, "UPDATE table1 SET tag = NULL", sqlFilter)
+	assert.Empty(t, args)
+}
+
 func TestFilterUpdateOk(t *testing.T) {
 
 	s, _ := NewMockProvider().UTInit()

--- a/pkg/ffapi/query_fields.go
+++ b/pkg/ffapi/query_fields.go
@@ -101,6 +101,16 @@ func (f *nullField) Scan(_ interface{}) error {
 }
 func (f *nullField) Value() (driver.Value, error) { return nil, nil }
 func (f *nullField) String() string               { return fftypes.NullString }
+func (f *nullField) isNull() bool                 { return true }
+
+type hasIsNull interface {
+	isNull() bool
+}
+
+func IsNull(v any) bool {
+	vAsIsNull, ok := v.(hasIsNull)
+	return ok && vAsIsNull.isNull()
+}
 
 type StringField struct{}
 type stringField struct {

--- a/pkg/ffapi/query_fields_test.go
+++ b/pkg/ffapi/query_fields_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestNullField(t *testing.T) {
 
-	f := nullField{}
+	f := &nullField{}
 	v, err := f.Value()
 	assert.NoError(t, err)
 	assert.Nil(t, v)
@@ -40,6 +40,7 @@ func TestNullField(t *testing.T) {
 	assert.Nil(t, v)
 
 	assert.Equal(t, "null", f.String())
+	assert.True(t, IsNull(f))
 }
 
 func TestStringField(t *testing.T) {

--- a/pkg/ffapi/update_test.go
+++ b/pkg/ffapi/update_test.go
@@ -45,11 +45,20 @@ func TestUpdateBuilderOK(t *testing.T) {
 	u.Set("sequence", 12345).
 		Set("cid", uuid).
 		Set("author", "0x1234").
-		Set("type", "private")
+		Set("type", "private").
+		SetNull("masked")
 	assert.False(t, u.IsEmpty())
 	ui, err := u.Finalize()
 	assert.NoError(t, err)
-	assert.Equal(t, "sequence=12345, cid='c414cab3-9bd4-48f3-b16a-0d74a3bbb60e', author='0x1234', type='private'", ui.String())
+	assert.Equal(t, "sequence=12345, cid='c414cab3-9bd4-48f3-b16a-0d74a3bbb60e', author='0x1234', type='private', masked=null", ui.String())
+}
+
+func TestUpdateBuilderSingleNull(t *testing.T) {
+	u := TestQueryFactory.NewUpdate(context.Background()).SetNull("masked")
+	assert.False(t, u.IsEmpty())
+	ui, err := u.Finalize()
+	assert.NoError(t, err)
+	assert.Equal(t, "masked=null", ui.String())
 }
 
 func TestUpdateBuilderBadField(t *testing.T) {


### PR DESCRIPTION
Without this PR, if you tried to do `.Set("fieldName", nil)` you would get:
```
FF00143: Unable to parse value for filter 'fieldName'
```