### PR TITLE
Update Swagger UI and allow JSON queries to specify `fields`

### DIFF
--- a/pkg/ffapi/openapihandler.go
+++ b/pkg/ffapi/openapihandler.go
@@ -48,15 +48,15 @@ func swaggerUIHTML(swaggerURL string) []byte {
     <title>Swagger UI</title>
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.6.2/swagger-ui.css">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.29.0/swagger-ui.css">
 		<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
   </head>
 
   <body>
     <div id="swagger-ui"></div>
 
-		<script src="https://unpkg.com/swagger-ui-dist@5.6.2/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
-		<script src="https://unpkg.com/swagger-ui-dist@5.6.2/swagger-ui-bundle.js" charset="UTF-8"></script>
+		<script src="https://unpkg.com/swagger-ui-dist@5.29.0/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
+		<script src="https://unpkg.com/swagger-ui-dist@5.29.0/swagger-ui-bundle.js" charset="UTF-8"></script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region

--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -93,10 +93,11 @@ type FilterJSONOps struct {
 
 type QueryJSON struct {
 	FilterJSON
-	Skip  *uint64  `ffstruct:"FilterJSON" json:"skip,omitempty"`
-	Limit *uint64  `ffstruct:"FilterJSON" json:"limit,omitempty"`
-	Sort  []string `ffstruct:"FilterJSON" json:"sort,omitempty"`
-	Count *bool    `ffstruct:"FilterJSON" json:"count,omitempty"`
+	Skip   *uint64  `ffstruct:"FilterJSON" json:"skip,omitempty"`
+	Limit  *uint64  `ffstruct:"FilterJSON" json:"limit,omitempty"`
+	Sort   []string `ffstruct:"FilterJSON" json:"sort,omitempty"`
+	Count  *bool    `ffstruct:"FilterJSON" json:"count,omitempty"`
+	Fields []string `ffstruct:"FilterJSON" json:"fields,omitempty"`
 }
 
 type SimpleFilterValue string
@@ -177,6 +178,9 @@ func (jq *QueryJSON) BuildFilter(ctx context.Context, qf QueryFactory, options .
 	}
 	if jq.Limit != nil {
 		fb = fb.Limit(*jq.Limit)
+	}
+	if len(jq.Fields) > 0 {
+		fb = fb.RequiredFields(jq.Fields...)
 	}
 	if len(jq.Sort) > 0 {
 		rv := buildResolveCtx(ctx, &jq.FilterJSON, options...)

--- a/pkg/ffapi/restfilter_json_test.go
+++ b/pkg/ffapi/restfilter_json_test.go
@@ -33,6 +33,7 @@ func TestBuildQueryJSONNestedAndOr(t *testing.T) {
 	err := json.Unmarshal([]byte(`{
 		"skip": 5,
 		"limit": 10,
+		"fields": ["tag","masked","sequence","cid"],
 		"sort": [
 			"tag",
 			"-sequence"
@@ -109,7 +110,7 @@ func TestBuildQueryJSONNestedAndOr(t *testing.T) {
 	fi, err := filter.Finalize()
 	assert.NoError(t, err)
 
-	assert.Equal(t, "( tag == 'a' ) && ( masked == true ) && ( sequence != 999 ) && ( cid == null ) && ( sequence >> 10 ) && ( ( ( masked == true ) && ( tag IN ['a','b','c'] ) && ( tag NI ['x','y'] ) && ( tag NI ['z'] ) ) || ( masked == false ) ) sort=tag,-sequence skip=5 limit=10", fi.String())
+	assert.Equal(t, "( tag == 'a' ) && ( masked == true ) && ( sequence != 999 ) && ( cid == null ) && ( sequence >> 10 ) && ( ( ( masked == true ) && ( tag IN ['a','b','c'] ) && ( tag NI ['x','y'] ) && ( tag NI ['z'] ) ) || ( masked == false ) ) requiredFields=tag,masked,sequence,cid sort=tag,-sequence skip=5 limit=10", fi.String())
 }
 
 func TestBuildQuerySingleNestedOr(t *testing.T) {

--- a/pkg/i18n/en_base_field_descriptions.go
+++ b/pkg/i18n/en_base_field_descriptions.go
@@ -44,6 +44,7 @@ var (
 	FilterJSONSort               = ffm("FilterJSON.sort", "Array of fields to sort by. A '-' prefix on a field requests that field is sorted in descending order")
 	FilterJSONCount              = ffm("FilterJSON.count", "If true, the total number of entries that could be returned from the database will be calculated and returned as a 'total' (has a performance cost)")
 	FilterJSONOr                 = ffm("FilterJSON.or", "Array of sub-queries where any sub-query can match to return results (OR combined). Note that within each sub-query all filters must match (AND combined)")
+	FilterJSONFields             = ffm("FilterJSON.fields", "Fields to return in the response")
 
 	EventStreamBatchSize         = ffm("eventstream.batchSize", "Maximum number of events to deliver in each batch")
 	EventStreamBatchTimeout      = ffm("eventstream.batchTimeout", "Amount of time to wait for events to arrive before delivering an incomplete batch")


### PR DESCRIPTION
- Updates Swagger UI lib to to 5.29.0 - felt like time to get an upgrade proposed
- Adds `fields` which were missing in the JSON query payload, to specify what fields should be returned
    - Already supported in the underlying filter capabilities