### PR TITLE
JSON query builder

### DIFF
--- a/pkg/ffapi/openapihandler.go
+++ b/pkg/ffapi/openapihandler.go
@@ -48,15 +48,15 @@ func swaggerUIHTML(swaggerURL string) []byte {
     <title>Swagger UI</title>
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.6.2/swagger-ui.css">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.29.0/swagger-ui.css">
 		<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
   </head>
 
   <body>
     <div id="swagger-ui"></div>
 
-		<script src="https://unpkg.com/swagger-ui-dist@5.6.2/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
-		<script src="https://unpkg.com/swagger-ui-dist@5.6.2/swagger-ui-bundle.js" charset="UTF-8"></script>
+		<script src="https://unpkg.com/swagger-ui-dist@5.29.0/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
+		<script src="https://unpkg.com/swagger-ui-dist@5.29.0/swagger-ui-bundle.js" charset="UTF-8"></script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region

--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -456,3 +456,11 @@ func (jf *FilterJSON) BuildAndFilter(ctx context.Context, fb FilterBuilder, opti
 	}
 	return andFilter, nil
 }
+
+// Converts to a builder - which will add to the underlying query structure (cannot remove existing elements)
+func (jq *QueryJSON) ToBuilder() QueryBuilder {
+	return &queryBuilderImpl{
+		rootQuery:  jq,
+		statements: &jq.FilterJSON,
+	}
+}

--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -93,10 +93,11 @@ type FilterJSONOps struct {
 
 type QueryJSON struct {
 	FilterJSON
-	Skip  *uint64  `ffstruct:"FilterJSON" json:"skip,omitempty"`
-	Limit *uint64  `ffstruct:"FilterJSON" json:"limit,omitempty"`
-	Sort  []string `ffstruct:"FilterJSON" json:"sort,omitempty"`
-	Count *bool    `ffstruct:"FilterJSON" json:"count,omitempty"`
+	Skip   *uint64  `ffstruct:"FilterJSON" json:"skip,omitempty"`
+	Limit  *uint64  `ffstruct:"FilterJSON" json:"limit,omitempty"`
+	Sort   []string `ffstruct:"FilterJSON" json:"sort,omitempty"`
+	Count  *bool    `ffstruct:"FilterJSON" json:"count,omitempty"`
+	Fields []string `ffstruct:"FilterJSON" json:"fields,omitempty"`
 }
 
 type SimpleFilterValue string
@@ -177,6 +178,9 @@ func (jq *QueryJSON) BuildFilter(ctx context.Context, qf QueryFactory, options .
 	}
 	if jq.Limit != nil {
 		fb = fb.Limit(*jq.Limit)
+	}
+	if len(jq.Fields) > 0 {
+		fb = fb.RequiredFields(jq.Fields...)
 	}
 	if len(jq.Sort) > 0 {
 		rv := buildResolveCtx(ctx, &jq.FilterJSON, options...)

--- a/pkg/ffapi/restfilter_json_builder.go
+++ b/pkg/ffapi/restfilter_json_builder.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffapi/restfilter_json_builder.go
+++ b/pkg/ffapi/restfilter_json_builder.go
@@ -1,0 +1,212 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ffapi
+
+import (
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+)
+
+type addOns func(op *FilterJSONBase)
+
+var (
+	// AddOns is a map of add-ons to be used in the query
+	Not             addOns = func(op *FilterJSONBase) { op.Not = true }
+	CaseInsensitive addOns = func(op *FilterJSONBase) { op.CaseInsensitive = true }
+	CaseSensitive   addOns = func(op *FilterJSONBase) { op.CaseInsensitive = false }
+)
+
+// QueryBuilder defines an interface for building queries
+type QueryBuilder interface {
+
+	// Limit sets the limit of the query
+	Limit(limit uint64) QueryBuilder
+
+	// Sort adds a sort filter to the query
+	Sort(fields ...string) QueryBuilder
+
+	// Equal adds an equal filter to the query
+	Equal(field string, value any, adds ...addOns) QueryBuilder
+
+	// NotEqual adds a not equal filter to the query
+	NotEqual(field string, value any, adds ...addOns) QueryBuilder
+
+	// GreaterThan adds a greater than filter to the query
+	GreaterThan(field string, value any) QueryBuilder
+
+	// GreaterThanOrEqual adds a greater than or equal filter to the query
+	GreaterThanOrEqual(field string, value any) QueryBuilder
+
+	// LessThan adds a less than filter to the query
+	LessThan(field string, value any) QueryBuilder
+
+	// LessThanOrEqual adds a less than or equal filter to the query
+	LessThanOrEqual(field string, value any) QueryBuilder
+
+	// In adds an in filter to the query
+	In(field string, values []any, adds ...addOns) QueryBuilder
+
+	// NotIn adds a not in filter to the query
+	NotIn(field string, values []any, adds ...addOns) QueryBuilder
+
+	// Null adds an is null filter to the query
+	Null(field string) QueryBuilder
+
+	// NotNull adds an is not null filter to the query
+	NotNull(field string) QueryBuilder
+
+	// Or creates an OR condition between multiple queries
+	Or(...QueryBuilder) QueryBuilder
+
+	// Query returns the query
+	Query() *QueryJSON
+}
+
+// Ensure queryBuilderImpl implements QueryBuilder
+var _ QueryBuilder = &queryBuilderImpl{}
+
+type queryBuilderImpl struct {
+	rootQuery  *QueryJSON
+	statements *FilterJSON
+}
+
+func NewQueryBuilder() QueryBuilder {
+	qj := &QueryJSON{}
+	return qj.ToBuilder()
+}
+
+// Limit sets the limit of the query
+func (qb *queryBuilderImpl) Limit(limit uint64) QueryBuilder {
+	qb.rootQuery.Limit = &limit
+	return qb
+}
+
+// Sort adds a sort filter to the query
+func (qb *queryBuilderImpl) Sort(fields ...string) QueryBuilder {
+	qb.rootQuery.Sort = append(qb.rootQuery.Sort, fields...)
+	return qb
+}
+
+func buildOp(field string, adds ...addOns) *FilterJSONBase {
+	op := &FilterJSONBase{
+		Field: field,
+	}
+	for _, add := range adds {
+		add(op)
+	}
+	return op
+}
+
+func toSimpleValue(v any) SimpleFilterValue {
+	switch vt := v.(type) {
+	case string:
+		return SimpleFilterValue(vt)
+	default:
+		// As the interface requires everything to be a string, we try and support a range
+		// of values using existing functions. Could be improved in the future.
+		return toSimpleValue((fftypes.JSONObject{"v": v}).GetString("v"))
+	}
+}
+
+func buildSingleValueOp(field string, value any, adds ...addOns) *FilterJSONKeyValue {
+	return &FilterJSONKeyValue{
+		FilterJSONBase: *buildOp(field, adds...),
+		Value:          toSimpleValue(value),
+	}
+}
+
+func buildMultiValueOp(field string, values []any, adds ...addOns) *FilterJSONKeyValues {
+	omv := &FilterJSONKeyValues{
+		FilterJSONBase: *buildOp(field, adds...),
+	}
+	for _, value := range values {
+		omv.Values = append(omv.Values, toSimpleValue(value))
+	}
+	return omv
+}
+
+// Equal adds an equal filter to the query
+func (qb *queryBuilderImpl) Equal(field string, value any, adds ...addOns) QueryBuilder {
+	qb.statements.Eq = append(qb.statements.Eq, buildSingleValueOp(field, value, adds...))
+	return qb
+}
+
+// NotEqual adds a not equal filter to the query
+func (qb *queryBuilderImpl) NotEqual(field string, value any, adds ...addOns) QueryBuilder {
+	qb.statements.NEq = append(qb.statements.NEq, buildSingleValueOp(field, value, adds...))
+	return qb
+}
+
+// GreaterThan adds a greater than filter to the query
+func (qb *queryBuilderImpl) GreaterThan(field string, value any) QueryBuilder {
+	qb.statements.GT = append(qb.statements.GT, buildSingleValueOp(field, value))
+	return qb
+}
+
+// GreaterThanOrEqual adds a greater than or equal filter to the query
+func (qb *queryBuilderImpl) GreaterThanOrEqual(field string, value any) QueryBuilder {
+	qb.statements.GTE = append(qb.statements.GTE, buildSingleValueOp(field, value))
+	return qb
+}
+
+// LessThan adds a less than filter to the query
+func (qb *queryBuilderImpl) LessThan(field string, value any) QueryBuilder {
+	qb.statements.LT = append(qb.statements.LT, buildSingleValueOp(field, value))
+	return qb
+}
+
+// LessThanOrEqual adds a less than or equal filter to the query
+func (qb *queryBuilderImpl) LessThanOrEqual(field string, value any) QueryBuilder {
+	qb.statements.LTE = append(qb.statements.LTE, buildSingleValueOp(field, value))
+	return qb
+}
+
+// In adds an in filter to the query
+func (qb *queryBuilderImpl) In(field string, values []any, adds ...addOns) QueryBuilder {
+	qb.statements.In = append(qb.statements.In, buildMultiValueOp(field, values, adds...))
+	return qb
+}
+
+// NotIn adds a not in filter to the query
+func (qb *queryBuilderImpl) NotIn(field string, values []any, adds ...addOns) QueryBuilder {
+	qb.statements.NIn = append(qb.statements.NIn, buildMultiValueOp(field, values, adds...))
+	return qb
+}
+
+// Null adds an is null filter to the query
+func (qb *queryBuilderImpl) Null(field string) QueryBuilder {
+	qb.statements.Null = append(qb.statements.Null, buildOp(field))
+	return qb
+}
+
+// NotNull adds an is not null filter to the query
+func (qb *queryBuilderImpl) NotNull(field string) QueryBuilder {
+	qb.statements.Null = append(qb.statements.Null, buildOp(field, Not))
+	return qb
+}
+
+// Or creates an OR condition between multiple queries
+func (qb *queryBuilderImpl) Or(q ...QueryBuilder) QueryBuilder {
+	for _, child := range q {
+		qb.statements.Or = append(qb.statements.Or, child.(*queryBuilderImpl).statements)
+	}
+	return qb
+}
+
+// Query returns the query
+func (qb *queryBuilderImpl) Query() *QueryJSON {
+	return qb.rootQuery
+}

--- a/pkg/ffapi/restfilter_json_builder_test.go
+++ b/pkg/ffapi/restfilter_json_builder_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Kaleido, Inc.
+// Copyright © 2025 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/ffapi/restfilter_json_builder_test.go
+++ b/pkg/ffapi/restfilter_json_builder_test.go
@@ -1,0 +1,521 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ffapi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// LimitKey is the key for the limit field in the query
+	limitKey = "limit"
+	// SortKey is the key for the sort field in the query
+	sortKey = "sort"
+	// EqKey is the key for the eq field in the query
+	eqKey = "eq"
+	// NqKey is the key for the nq field in the query
+	// nqKey = "neq"
+	// GtKey is the key for the gt field in the query
+	// gtKey = "gt"
+	// LtKey is the key for the lt field in the query
+	// ltKey = "lt"
+	// LeKey is the key for the less than or equal field in the query
+	// leKey = "lte"
+	// GeKey is the key for the greater than or equal field in the query
+	// geKey = "gte"
+	// InKey is the key for the in field in the query
+	inKey = "in"
+	// NinKey is the key for the not in field in the query
+	ninKey = "nin"
+	// isNullKey is the key for the is null field in the query
+	isNullKey = "null"
+	// LikeKey is the key for the like field in the query
+	likeKey = "like"
+	// CaseInsensitiveKey is the key for the case insensitive flag in the query
+	// caseInsensitiveKey = "caseInsensitive"
+)
+
+func TestQuery(t *testing.T) {
+	expectedQuery := `{
+        "limit": 10,
+        "sort": ["field1 DESC","field2"],
+        "eq": [
+            { "field": "field1", "value": "value1" },
+            { "field": "field12", "value": "value12", "not": true, "caseInsensitive": true }
+        ],
+        "neq": [
+            { "field": "field2", "value": "value2" }
+        ],
+        "lt": [
+            { "field": "field4", "value": "12345" }
+        ],
+        "lte": [
+            { "field": "field5", "value": "23456" }
+        ],
+        "gt": [
+            { "field": "field6", "value": "34567" }
+        ],
+        "gte": [
+            { "field": "field7", "value": "45678" }
+        ],
+        "in": [
+            { "field": "field8", "values": ["a","b","c"] }
+        ],
+        "nin": [
+            { "field": "field9", "values": ["x","y","z"] }
+        ],
+        "null": [
+            { "field": "field10", "not": true },
+            { "field": "field11" }
+        ]
+    }`
+
+	query := NewQueryBuilder().
+		Limit(10).
+		Sort("field1 DESC").Sort("field2").
+		Equal("field1", "value1", CaseSensitive).
+		NotEqual("field2", "value2").
+		LessThan("field4", 12345).
+		LessThanOrEqual("field5", 23456).
+		GreaterThan("field6", 34567).
+		GreaterThanOrEqual("field7", 45678).
+		In("field8", []any{"a", "b", "c"}).
+		NotIn("field9", []any{"x", "y", "z"}).
+		NotNull("field10").
+		Null("field11").
+		Equal("field12", "value12", Not, CaseInsensitive).
+		Query()
+
+	jsonQuery, err := json.Marshal(query)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expectedQuery, string(jsonQuery))
+
+}
+
+func TestQuery_StringOr(t *testing.T) {
+	expectedQuery := `{
+        "or": [
+            {
+                "eq": [
+                    { "field": "field1", "value": "value1" }
+                ],
+                "neq": [
+                    { "field": "field2", "value": "value2" }
+                ]
+            },
+            {
+                "eq": [
+                    { "field": "field3", "value": "value3" }
+                ],
+                "neq": [
+                    { "field": "field4", "value": "value4" }
+                ]
+            }
+        ]
+    }`
+
+	query := NewQueryBuilder().
+		Or(
+			NewQueryBuilder().
+				Equal("field1", "value1").
+				NotEqual("field2", "value2"),
+		).
+		Or(
+			NewQueryBuilder().
+				Equal("field3", "value3").
+				NotEqual("field4", "value4"),
+		).
+		Query()
+
+	jsonQuery, err := json.Marshal(query)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expectedQuery, string(jsonQuery))
+}
+
+func assertQueryEqual(t *testing.T, jsonMap map[string]interface{}, jq *QueryJSON) {
+	jmb, err := json.Marshal(jsonMap)
+	assert.NoError(t, err)
+	jqb, err := json.Marshal(jq)
+	assert.NoError(t, err)
+	assert.JSONEq(t, string(jmb), string(jqb))
+}
+
+func TestQueryBuilderImpl_Limit(t *testing.T) {
+	tests := []struct {
+		name     string
+		limit    int
+		expected map[string]interface{}
+	}{
+		{
+			name:  "Set positive limit",
+			limit: 10,
+			expected: map[string]interface{}{
+				limitKey: int(10),
+			},
+		},
+		{
+			name:  "Set zero limit",
+			limit: 0,
+			expected: map[string]interface{}{
+				limitKey: int(0),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := NewQueryBuilder()
+			qb.Limit(uint64(tt.limit))
+			assertQueryEqual(t, tt.expected, qb.Query())
+		})
+	}
+}
+func TestQueryBuilderImpl_Sort(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   []string
+		expected map[string]interface{}
+	}{
+		{
+			name:   "Set single sort field",
+			fields: []string{"field1"},
+			expected: map[string]interface{}{
+				sortKey: []string{"field1"},
+			},
+		},
+		{
+			name:   "Set multiple sort fields",
+			fields: []string{"field1", "field2"},
+			expected: map[string]interface{}{
+				sortKey: []string{"field1", "field2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := NewQueryBuilder()
+			for _, field := range tt.fields {
+				qb.Sort(field)
+			}
+			assertQueryEqual(t, tt.expected, qb.Query())
+		})
+	}
+}
+
+func TestQueryBuilderImpl_In(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    string
+		values   []any
+		adds     []addOns
+		expected map[string]interface{}
+	}{
+		{
+			name:   "Set single in field",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}},
+				},
+			},
+		},
+		{
+			name:   "Set in field with Not add-on",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{Not},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "not": true},
+				},
+			},
+		},
+		{
+			name:   "Set in field with CaseInsensitive add-on",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{CaseInsensitive},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "caseInsensitive": true},
+				},
+			},
+		},
+		{
+			name:   "Set in field with multiple add-ons",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{Not, CaseInsensitive},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "not": true, "caseInsensitive": true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := NewQueryBuilder()
+			qb.In(tt.field, tt.values, tt.adds...)
+			assertQueryEqual(t, tt.expected, qb.Query())
+		})
+	}
+}
+func TestQueryBuilderImpl_NotIn(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    string
+		values   []any
+		adds     []addOns
+		expected map[string]interface{}
+	}{
+		{
+			name:   "Set single not in field",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			expected: map[string]interface{}{
+				ninKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}},
+				},
+			},
+		},
+		{
+			name:   "Set not in field with Not add-on",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{Not},
+			expected: map[string]interface{}{
+				ninKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "not": true},
+				},
+			},
+		},
+		{
+			name:   "Set not in field with CaseInsensitive add-on",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{CaseInsensitive},
+			expected: map[string]interface{}{
+				ninKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "caseInsensitive": true},
+				},
+			},
+		},
+		{
+			name:   "Set not in field with multiple add-ons",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{Not, CaseInsensitive},
+			expected: map[string]interface{}{
+				ninKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "not": true, "caseInsensitive": true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := NewQueryBuilder()
+			qb.NotIn(tt.field, tt.values, tt.adds...)
+
+			assertQueryEqual(t, tt.expected, qb.Query())
+		})
+	}
+}
+func TestQueryBuilderImpl_Null(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    string
+		expected map[string]interface{}
+	}{
+		{
+			name:  "Set single is null field",
+			field: "name",
+			expected: map[string]interface{}{
+				isNullKey: []map[string]interface{}{
+					{"field": "name"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := NewQueryBuilder()
+			qb.Null(tt.field)
+			assertQueryEqual(t, tt.expected, qb.Query())
+		})
+	}
+}
+
+func TestQueryBuilderImpl_setField(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    string
+		value    interface{}
+		adds     []addOns
+		expected map[string]interface{}
+	}{
+		{
+			name:  "Set single field",
+			field: "name",
+			value: "John",
+			expected: map[string]interface{}{
+				eqKey: []map[string]interface{}{
+					{"field": "name", "value": "John"},
+				},
+			},
+		},
+		{
+			name:  "Set field with Not add-on",
+			field: "name",
+			value: "John",
+			adds:  []addOns{Not},
+			expected: map[string]interface{}{
+				eqKey: []map[string]interface{}{
+					{"field": "name", "value": "John", "not": true},
+				},
+			},
+		},
+		{
+			name:  "Set field with CaseInsensitive add-on",
+			field: "name",
+			value: "John",
+			adds:  []addOns{CaseInsensitive},
+			expected: map[string]interface{}{
+				eqKey: []map[string]interface{}{
+					{"field": "name", "value": "John", "caseInsensitive": true},
+				},
+			},
+		},
+		{
+			name:  "Set field with multiple add-ons",
+			field: "name",
+			value: "John",
+			adds:  []addOns{Not, CaseInsensitive},
+			expected: map[string]interface{}{
+				eqKey: []map[string]interface{}{
+					{"field": "name", "value": "John", "not": true, "caseInsensitive": true},
+				},
+			},
+		},
+		{
+			name:  "Set multiple fields",
+			field: "name",
+			value: "John",
+			expected: map[string]interface{}{
+				eqKey: []map[string]interface{}{
+					{"field": "name", "value": "John"},
+					{"field": "age", "value": "30"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := NewQueryBuilder()
+			qb = qb.Equal(tt.field, tt.value, tt.adds...)
+			if tt.name == "Set multiple fields" {
+				qb = qb.Equal("age", "30", tt.adds...)
+			}
+			assertQueryEqual(t, tt.expected, qb.Query())
+		})
+	}
+}
+func TestQueryBuilderImpl_setFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    string
+		values   []any
+		adds     []addOns
+		expected map[string]interface{}
+	}{
+		{
+			name:   "Set single field with values",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}},
+				},
+			},
+		},
+		{
+			name:   "Set field with Not add-on",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{Not},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "not": true},
+				},
+			},
+		},
+		{
+			name:   "Set field with CaseInsensitive add-on",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{CaseInsensitive},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "caseInsensitive": true},
+				},
+			},
+		},
+		{
+			name:   "Set field with multiple add-ons",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			adds:   []addOns{Not, CaseInsensitive},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}, "not": true, "caseInsensitive": true},
+				},
+			},
+		},
+		{
+			name:   "Set multiple fields",
+			field:  "name",
+			values: []any{"John", "Doe"},
+			expected: map[string]interface{}{
+				inKey: []map[string]interface{}{
+					{"field": "name", "values": []string{"John", "Doe"}},
+					{"field": "age", "values": []string{"30", "40"}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qb := NewQueryBuilder()
+			qb = qb.In(tt.field, tt.values, tt.adds...)
+			if tt.name == "Set multiple fields" {
+				qb = qb.In("age", []any{"30", "40"})
+			}
+			assertQueryEqual(t, tt.expected, qb.Query())
+		})
+	}
+}

--- a/pkg/ffapi/restfilter_json_test.go
+++ b/pkg/ffapi/restfilter_json_test.go
@@ -33,6 +33,7 @@ func TestBuildQueryJSONNestedAndOr(t *testing.T) {
 	err := json.Unmarshal([]byte(`{
 		"skip": 5,
 		"limit": 10,
+		"fields": ["tag","masked","sequence","cid"],
 		"sort": [
 			"tag",
 			"-sequence"
@@ -109,7 +110,7 @@ func TestBuildQueryJSONNestedAndOr(t *testing.T) {
 	fi, err := filter.Finalize()
 	assert.NoError(t, err)
 
-	assert.Equal(t, "( tag == 'a' ) && ( masked == true ) && ( sequence != 999 ) && ( cid == null ) && ( sequence >> 10 ) && ( ( ( masked == true ) && ( tag IN ['a','b','c'] ) && ( tag NI ['x','y'] ) && ( tag NI ['z'] ) ) || ( masked == false ) ) sort=tag,-sequence skip=5 limit=10", fi.String())
+	assert.Equal(t, "( tag == 'a' ) && ( masked == true ) && ( sequence != 999 ) && ( cid == null ) && ( sequence >> 10 ) && ( ( ( masked == true ) && ( tag IN ['a','b','c'] ) && ( tag NI ['x','y'] ) && ( tag NI ['z'] ) ) || ( masked == false ) ) requiredFields=tag,masked,sequence,cid sort=tag,-sequence skip=5 limit=10", fi.String())
 }
 
 func TestBuildQuerySingleNestedOr(t *testing.T) {

--- a/pkg/i18n/en_base_field_descriptions.go
+++ b/pkg/i18n/en_base_field_descriptions.go
@@ -44,6 +44,7 @@ var (
 	FilterJSONSort               = ffm("FilterJSON.sort", "Array of fields to sort by. A '-' prefix on a field requests that field is sorted in descending order")
 	FilterJSONCount              = ffm("FilterJSON.count", "If true, the total number of entries that could be returned from the database will be calculated and returned as a 'total' (has a performance cost)")
 	FilterJSONOr                 = ffm("FilterJSON.or", "Array of sub-queries where any sub-query can match to return results (OR combined). Note that within each sub-query all filters must match (AND combined)")
+	FilterJSONFields             = ffm("FilterJSON.fields", "Fields to return in the response")
 
 	EventStreamBatchSize         = ffm("eventstream.batchSize", "Maximum number of events to deliver in each batch")
 	EventStreamBatchTimeout      = ffm("eventstream.batchTimeout", "Amount of time to wait for events to arrive before delivering an incomplete batch")


### PR DESCRIPTION
- In PR chain with #190 

Adds a useful Go structure to allow a much more compact way for Go code to build JSON query structures:

https://github.com/hyperledger/firefly-common/blob/153db91fe6c539cff9bee637f42bba673869f294/pkg/ffapi/restfilter_json_builder_test.go#L90-L104

> Note this ports back a piece of work that was done in a separate LFDT OSS project (Paladin) that uses the same JSON format for querying.
