### PR TITLE
Add ability to exclude a specific route from the OpenAPI and expose SwaggerHTML

### DIFF
--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -120,6 +120,10 @@ func (sg *SwaggerGen) Generate(ctx context.Context, routes []*Route) *openapi3.T
 	}
 	opIDs := make(map[string]bool)
 	for _, route := range routes {
+		// Skip routes that are excluded from OpenAPI generation
+		if route.ExcludeFromOpenAPI {
+			continue
+		}
 		if route.Name == "" || opIDs[route.Name] {
 			log.Panicf("Duplicate/invalid name (used as operation ID in swagger): %s", route.Name)
 		}

--- a/pkg/ffapi/openapihandler.go
+++ b/pkg/ffapi/openapihandler.go
@@ -39,7 +39,7 @@ type OpenAPIHandlerFactory struct {
 	DynamicPublicURLBuilder func(req *http.Request) string
 }
 
-func swaggerUIHTML(swaggerURL string) []byte {
+func SwaggerUIHTML(swaggerURL string) []byte {
 	return []byte(fmt.Sprintf(
 		`<!DOCTYPE html>
 <html lang="en">
@@ -150,7 +150,7 @@ func (ohf *OpenAPIHandlerFactory) OpenAPIHandlerVersioned(apiPath string, format
 func (ohf *OpenAPIHandlerFactory) SwaggerUIHandler(openAPIPath string) HandlerFunction {
 	return func(res http.ResponseWriter, req *http.Request) (status int, err error) {
 		res.Header().Add("Content-Type", "text/html")
-		_, _ = res.Write(swaggerUIHTML(ohf.getPublicURL(req, openAPIPath)))
+		_, _ = res.Write(SwaggerUIHTML(ohf.getPublicURL(req, openAPIPath)))
 		return 200, nil
 	}
 }

--- a/pkg/ffapi/routes.go
+++ b/pkg/ffapi/routes.go
@@ -79,6 +79,8 @@ type Route struct {
 	Deprecated bool
 	// Tag a category identifier for this route in the generated OpenAPI spec
 	Tag string
+	// ExcludeFromOpenAPI if true, this route will not be included in the generated OpenAPI specification
+	ExcludeFromOpenAPI bool
 	// Extensions allows extension of the route struct by individual microservices
 	Extensions interface{}
 }


### PR DESCRIPTION
New `ExcludeFromOpenAPI` to exclude a route from showing up in the OpenAPI and expose the SwaggerHTML instead of only allowing to access it through a `HandlerFunction` 