### PR TITLE
do not mutate scoped filter

### DIFF
--- a/pkg/dbsql/crud.go
+++ b/pkg/dbsql/crud.go
@@ -279,7 +279,7 @@ func (c *CrudBase[T]) idFilter(id string) sq.Eq {
 		filter[c.idField()] = id
 	}
 	if c.ScopedFilter != nil {
-		//copy the fields from the scoped filter without modifying the original
+		// copy the fields from the scoped filter without modifying the original
 		for k, v := range c.ScopedFilter() {
 			filter[k] = v
 		}

--- a/pkg/dbsql/crud.go
+++ b/pkg/dbsql/crud.go
@@ -271,16 +271,18 @@ func (c *CrudBase[T]) idField() string {
 }
 
 func (c *CrudBase[T]) idFilter(id string) sq.Eq {
-	var filter sq.Eq
-	if c.ScopedFilter != nil {
-		filter = c.ScopedFilter()
-	} else {
-		filter = sq.Eq{}
-	}
+	filter := sq.Eq{}
+
 	if c.ReadTableAlias != "" {
 		filter[fmt.Sprintf("%s.%s", c.ReadTableAlias, c.GetIDField())] = id
 	} else {
 		filter[c.idField()] = id
+	}
+	if c.ScopedFilter != nil {
+		//copy the fields from the scoped filter without modifying the original
+		for k, v := range c.ScopedFilter() {
+			filter[k] = v
+		}
 	}
 	return filter
 }


### PR DESCRIPTION
`idFilter` was modifying the scoped filter on a collection with an `id` filter condition and any attempts read from that collection afterwards, would always be scoped to a single record.

This PR changes that so we now only read from the scoped filter and do not modify it.