### PR TITLE
Add option for explicit nested AND sub-queries

### DIFF
--- a/pkg/ffapi/restfilter_json.go
+++ b/pkg/ffapi/restfilter_json.go
@@ -67,7 +67,8 @@ type FilterJSONKeyValues struct {
 }
 
 type FilterJSON struct {
-	Or []*FilterJSON `ffstruct:"FilterJSON" json:"or,omitempty"`
+	Or  []*FilterJSON `ffstruct:"FilterJSON" json:"or,omitempty"`
+	And []*FilterJSON `ffstruct:"FilterJSON" json:"and,omitempty"`
 	FilterJSONOps
 }
 
@@ -434,6 +435,13 @@ func (jf *FilterJSON) BuildAndFilter(ctx context.Context, fb FilterBuilder, opti
 		} else {
 			andFilter = andFilter.Condition(fb.In(field, rv.resolveMany(field, e.Values)))
 		}
+	}
+	for _, child := range jf.And {
+		subFilter, err := child.BuildSubFilter(ctx, fb, options...)
+		if err != nil {
+			return nil, err
+		}
+		andFilter.Condition(subFilter)
 	}
 	if len(jf.Or) > 0 {
 		childFilter := fb.Or()

--- a/pkg/ffapi/restfilter_json_builder.go
+++ b/pkg/ffapi/restfilter_json_builder.go
@@ -71,7 +71,7 @@ type QueryBuilder interface {
 	// Or creates an OR condition between multiple queries
 	Or(...QueryBuilder) QueryBuilder
 
-	// And creates an OR condition between multiple queries
+	// And creates an AND condition between multiple queries
 	And(...QueryBuilder) QueryBuilder
 
 	// Query returns the query

--- a/pkg/ffapi/restfilter_json_builder.go
+++ b/pkg/ffapi/restfilter_json_builder.go
@@ -213,7 +213,7 @@ func (qb *queryBuilderImpl) Or(q ...QueryBuilder) QueryBuilder {
 	return qb
 }
 
-// Or creates an AND condition between multiple queries
+// And creates an AND condition between multiple queries
 func (qb *queryBuilderImpl) And(q ...QueryBuilder) QueryBuilder {
 	for _, child := range q {
 		qb.statements.And = append(qb.statements.And, child.(*queryBuilderImpl).statements)

--- a/pkg/ffapi/restfilter_json_builder.go
+++ b/pkg/ffapi/restfilter_json_builder.go
@@ -71,6 +71,9 @@ type QueryBuilder interface {
 	// Or creates an OR condition between multiple queries
 	Or(...QueryBuilder) QueryBuilder
 
+	// And creates an OR condition between multiple queries
+	And(...QueryBuilder) QueryBuilder
+
 	// Query returns the query
 	Query() *QueryJSON
 }
@@ -86,6 +89,10 @@ type queryBuilderImpl struct {
 func NewQueryBuilder() QueryBuilder {
 	qj := &QueryJSON{}
 	return qj.ToBuilder()
+}
+
+func QB() QueryBuilder {
+	return NewQueryBuilder()
 }
 
 // Limit sets the limit of the query
@@ -202,6 +209,14 @@ func (qb *queryBuilderImpl) NotNull(field string) QueryBuilder {
 func (qb *queryBuilderImpl) Or(q ...QueryBuilder) QueryBuilder {
 	for _, child := range q {
 		qb.statements.Or = append(qb.statements.Or, child.(*queryBuilderImpl).statements)
+	}
+	return qb
+}
+
+// Or creates an AND condition between multiple queries
+func (qb *queryBuilderImpl) And(q ...QueryBuilder) QueryBuilder {
+	for _, child := range q {
+		qb.statements.And = append(qb.statements.And, child.(*queryBuilderImpl).statements)
 	}
 	return qb
 }

--- a/pkg/ffapi/restfilter_json_builder_test.go
+++ b/pkg/ffapi/restfilter_json_builder_test.go
@@ -149,6 +149,49 @@ func TestQuery_StringOr(t *testing.T) {
 	assert.JSONEq(t, expectedQuery, string(jsonQuery))
 }
 
+func TestQuery_AndNestedOr(t *testing.T) {
+	expectedQuery := `{
+	    "and": [
+			{
+				"eq": [
+					{ "field": "field1", "value": "aaa" }
+				]
+			},
+			{
+				"or": [
+					{
+						"eq": [
+							{ "field": "field2", "value": "bbb" }
+						]
+					},
+					{
+						"eq": [
+							{ "field": "field2", "value": "ccc" }
+						]
+					}
+				]
+			}
+		]
+    }`
+
+	query := QB().
+		And(
+			QB().Equal("field1", "aaa"),
+			QB().
+				Or(
+					QB().Equal("field2", "bbb"),
+				).
+				Or(
+					QB().Equal("field2", "ccc"),
+				),
+		).
+		Query()
+
+	jsonQuery, err := json.Marshal(query)
+	assert.NoError(t, err)
+	assert.JSONEq(t, expectedQuery, string(jsonQuery))
+}
+
 func assertQueryEqual(t *testing.T, jsonMap map[string]interface{}, jq *QueryJSON) {
 	jmb, err := json.Marshal(jsonMap)
 	assert.NoError(t, err)

--- a/pkg/i18n/en_base_field_descriptions.go
+++ b/pkg/i18n/en_base_field_descriptions.go
@@ -43,8 +43,8 @@ var (
 	FilterJSONSkip               = ffm("FilterJSON.skip", "Number of results to skip before returning entries, for skip+limit based pagination")
 	FilterJSONSort               = ffm("FilterJSON.sort", "Array of fields to sort by. A '-' prefix on a field requests that field is sorted in descending order")
 	FilterJSONCount              = ffm("FilterJSON.count", "If true, the total number of entries that could be returned from the database will be calculated and returned as a 'total' (has a performance cost)")
-	FilterJSONOr                 = ffm("FilterJSON.or", "Array of sub-queries where any sub-query can match to return results (OR combined). Note that within each sub-query all filters must match (AND combined)")
-	FilterJSONAnd                = ffm("FilterJSON.and", "Array of sub-queries where any sub-query can match to return results (AND combined). Allows complex construction, such as an AND of two nested OR sub-queries.")
+	FilterJSONOr                 = ffm("FilterJSON.or", "Array of sub-queries")  // Note due to complex issue in swagger generator AND/OR need to be identical
+	FilterJSONAnd                = ffm("FilterJSON.and", "Array of sub-queries") // ^^^ the `description` field is getting pushed to the sub-schema definition, and is non-deterministic
 	FilterJSONFields             = ffm("FilterJSON.fields", "Fields to return in the response")
 
 	EventStreamBatchSize         = ffm("eventstream.batchSize", "Maximum number of events to deliver in each batch")

--- a/pkg/i18n/en_base_field_descriptions.go
+++ b/pkg/i18n/en_base_field_descriptions.go
@@ -44,6 +44,7 @@ var (
 	FilterJSONSort               = ffm("FilterJSON.sort", "Array of fields to sort by. A '-' prefix on a field requests that field is sorted in descending order")
 	FilterJSONCount              = ffm("FilterJSON.count", "If true, the total number of entries that could be returned from the database will be calculated and returned as a 'total' (has a performance cost)")
 	FilterJSONOr                 = ffm("FilterJSON.or", "Array of sub-queries where any sub-query can match to return results (OR combined). Note that within each sub-query all filters must match (AND combined)")
+	FilterJSONAnd                = ffm("FilterJSON.and", "Array of sub-queries where any sub-query can match to return results (AND combined). Allows complex construction, such as an AND of two nested OR sub-queries.")
 	FilterJSONFields             = ffm("FilterJSON.fields", "Fields to return in the response")
 
 	EventStreamBatchSize         = ffm("eventstream.batchSize", "Maximum number of events to deliver in each batch")


### PR DESCRIPTION
I hit a scenario that I couldn't describe with our JSONQuery syntax.

See in this test, we have a top-level AND where one of the sub-queries is an OR. This couldn't be described before.

https://github.com/hyperledger/firefly-common/blob/8f24fbfd4a04c9f2ec80b80ac1dd1b8e2908611f/pkg/ffapi/restfilter_json_test.go#L145-L176