### PR TITLE
[ffapi] Ensure Default Log Level is Set in Handler

### DIFF
--- a/pkg/ffapi/handler.go
+++ b/pkg/ffapi/handler.go
@@ -365,8 +365,10 @@ func (hs *HandlerFactory) getTimeout(req *http.Request) time.Duration {
 }
 
 func (hs *HandlerFactory) APIWrapper(handler HandlerFunction) http.HandlerFunc {
+	if hs.apiEntryLoggingLevel == 0 {
+		hs.SetAPIEntryLoggingLevel(logrus.InfoLevel)
+	}
 	return func(res http.ResponseWriter, req *http.Request) {
-
 		reqTimeout := hs.getTimeout(req)
 		ctx, cancel := context.WithTimeout(req.Context(), reqTimeout)
 		httpReqID := req.Header.Get(RequestIDHeader())

--- a/pkg/ffapi/handler_test.go
+++ b/pkg/ffapi/handler_test.go
@@ -60,7 +60,6 @@ func newTestHandlerFactory(basePath string, basePathParams []*PathParam) *Handle
 		BasePath:       basePath,
 		BasePathParams: basePathParams,
 	}
-	hr.SetAPIEntryLoggingLevel(logrus.DebugLevel)
 	return hr
 }
 


### PR DESCRIPTION
Following up from #201 

Its a bit awkward - we added a private field to `HandlerFactory`. But `HandlerFactory` doesn't have a proper `New` func or `Init` to guarantee that internal log level field is set. If the log level field is not set and defaults to 0, then `logrus` panics on the first log message.

For most clients, they let `APIServer` construct and setup a `HandlerFactory`, so they are unaffected. But if anyone was initializing their own `HandlerFactory` and doesn't then call `SetAPIEntryLoggingLevel`, it would panic.

We don't want to check for 0 on every API request, as that would be inefficient, so we check when we construct `APIWrapper`'s who would depend on the log level to not be nil in order to fix this.

In a 2.0 of ff-common, we should likely make all fields of `HandlerFactory` private, have a `New` func, and use the [functional options](https://github.com/uber-go/guide/blob/master/style.md#functional-options) or builder pattern to provide a variadic way of setting all the possible fields (which is what a struct with public fields and no constructor feels like, but has potential for bugs like this one).