### PR TITLE
  adding support for DISTINCT ON for postgres DB

### DIFF
--- a/pkg/i18n/en_base_error_messages.go
+++ b/pkg/i18n/en_base_error_messages.go
@@ -1,4 +1,4 @@
-// Copyright © 2024 Kaleido, Inc.
+// Copyright © 2024 - 2026 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -192,4 +192,5 @@ var (
 	MsgRoutePathNotStartWithSlash                  = ffe("FF00255", "Route path '%s' must not start with '/'")
 	MsgMethodNotAllowed                            = ffe("FF00256", "Method not allowed", http.StatusMethodNotAllowed)
 	MsgInvalidLogLevel                             = ffe("FF00257", "Invalid log level: '%s'", http.StatusBadRequest)
+	MsgDistinctOnNotSupported                      = ffe("FF00258", "DISTINCT ON is only supported for PostgreSQL databases, but current provider is '%s'", 400)
 )


### PR DESCRIPTION
This PR adds support for PostgreSQL's `DISTINCT ON` clause to the firefly-common library, enabling efficient querying of distinct rows based on specific field combinations. This feature is PostgreSQL-specific and provides a more performant alternative to using `GROUP BY` or subqueries for deduplication scenarios.

## Postgres ONLY
The feature explicitly validates that the database provider is PostgreSQL before applying DISTINCT ON, returning a clear error message for unsupported providers.

## Usage Example

```go
filter := queryFactory.NewFilter(ctx).
    DistinctOn("namespace", "type").
    Sort("created").
    And()

results, _, err := collection.GetMany(ctx, filter)
```

This generates SQL like:
```sql
SELECT DISTINCT ON (namespace, type) * 
FROM table 
ORDER BY namespace, type, created
```