### PR TITLE
Fix concurrent map panic in webSocketServer.Close()

### DIFF
--- a/pkg/wsserver/wsserver.go
+++ b/pkg/wsserver/wsserver.go
@@ -127,7 +127,13 @@ func (s *webSocketServer) connectionClosed(c *webSocketConnection) {
 }
 
 func (s *webSocketServer) Close() {
+	s.mux.Lock()
+	conns := make([]*webSocketConnection, 0, len(s.connections))
 	for _, c := range s.connections {
+		conns = append(conns, c)
+	}
+	s.mux.Unlock()
+	for _, c := range conns {
 		c.close()
 	}
 }


### PR DESCRIPTION
`Close()` iterated `s.connections` without holding the mutex while connection goroutines concurrently called `connectionClosed()` → `delete(s.connections, ...)`, causing a `concurrent map iteration and map write` fatal panic (flaky in `TestBroadcastStartWithoutConnections`).

Fix: snapshot the connections slice under the lock before closing them, similar to the pattern already used in `Broadcast()`.
