### PR TITLE
Provide access to MonitoringPublicURL()

### DIFF
--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -53,6 +53,7 @@ type APIServer interface {
 	Started() <-chan struct{}
 	MuxRouter(ctx context.Context) (*mux.Router, error)
 	APIPublicURL() string // valid to call after server is successfully started
+	MonitoringPublicURL() string
 }
 
 type apiServer[T any] struct {


### PR DESCRIPTION
Currently if you start a test with port `0` for auto-allocate, you can't find out the monitoring URL to test the endpoints