### PR TITLE
expose option for openapi version

### DIFF
--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -44,6 +44,8 @@ type SwaggerGenOptions struct {
 	Version     string
 	Description string
 
+	OpenAPIVersion string
+
 	// descriptions for the route parameters are parsed from the ffstruct tags
 	// when set this flag to true, if a description is not found, the generator will panic
 	// this is useful to ensure that all fields are documented
@@ -113,8 +115,13 @@ func (sg *SwaggerGen) Generate(ctx context.Context, routes []*Route) *openapi3.T
 		}
 	}
 
+	openAPIVersion := "3.0.2"
+	if sg.options.OpenAPIVersion != "" {
+		openAPIVersion = sg.options.OpenAPIVersion
+	}
+
 	doc := &openapi3.T{
-		OpenAPI: "3.0.2",
+		OpenAPI: openAPIVersion,
 		Servers: openapi3.Servers{
 			server,
 		},

--- a/pkg/ffapi/openapi3_test.go
+++ b/pkg/ffapi/openapi3_test.go
@@ -208,17 +208,16 @@ var testRoutes = []*Route{
 		Tag: example2TagName,
 	},
 	{
-		Name:       "op8",
-		Path:       "example8",
-		Method:     http.MethodGet,
-		PathParams: nil,
-		QueryParams: nil,
-		Description: ExampleDesc,
-		JSONInputValue: func() interface{} { return nil},
+		Name:            "op8",
+		Path:            "example8",
+		Method:          http.MethodGet,
+		PathParams:      nil,
+		QueryParams:     nil,
+		Description:     ExampleDesc,
+		JSONInputValue:  func() interface{} { return nil },
 		JSONOutputValue: func() interface{} { return &TestExtensions{} },
 		JSONOutputCodes: []int{http.StatusOK},
 	},
-
 }
 
 type TestInOutType struct {
@@ -608,10 +607,10 @@ func TestExcludeFromOpenAPI(t *testing.T) {
 func TestExtensionsBadEncodingFail(t *testing.T) {
 	routes := []*Route{
 		{
-			Name:           "badEncoding",
-			Path:           "extensions",
-			Method:         http.MethodGet,
-			JSONInputValue: func() interface{} { return nil },
+			Name:            "badEncoding",
+			Path:            "extensions",
+			Method:          http.MethodGet,
+			JSONInputValue:  func() interface{} { return nil },
 			JSONOutputValue: func() interface{} { return &TestExtensionsBadEncoding{} },
 			JSONOutputCodes: []int{http.StatusOK},
 		},
@@ -629,10 +628,10 @@ func TestExtensionsBadEncodingFail(t *testing.T) {
 func TestExtensionsBadKeyFail(t *testing.T) {
 	routes := []*Route{
 		{
-			Name:           "bad3",
-			Path:           "extensions",
-			Method:         http.MethodGet,
-			JSONInputValue: func() interface{} { return nil },
+			Name:            "bad3",
+			Path:            "extensions",
+			Method:          http.MethodGet,
+			JSONInputValue:  func() interface{} { return nil },
 			JSONOutputValue: func() interface{} { return &TestExtensionsBadKey{} },
 			JSONOutputCodes: []int{http.StatusOK},
 		},
@@ -645,4 +644,16 @@ func TestExtensionsBadKeyFail(t *testing.T) {
 			BaseURL: "http://localhost:12345/api/v1",
 		}).Generate(context.Background(), routes)
 	})
+}
+
+func TestOpenAPIVersion(t *testing.T) {
+	doc := NewSwaggerGen(&SwaggerGenOptions{
+		Title:          "UnitTest",
+		Version:        "1.0",
+		OpenAPIVersion: "3.1.1",
+		BaseURL:        "http://localhost:12345/api/v1",
+	}).Generate(context.Background(), testRoutes)
+	err := doc.Validate(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "3.1.1", doc.OpenAPI)
 }


### PR DESCRIPTION
When using certain JSON schema constructs ( such as specifying type as an array), the generated API document will fail validation because those syntax were introduces in JSON Schema draft 2019-09.  OpenAPI 3.0.x aligns with earlier JSON Schema drafts where type MUST be a single string.

Open API 3.1.1 aligned with JSON Schema 2020-12 where type may be a string or an array of unique strings  .

So rather than hard coding the openapi version, this PR allows it to be configurable, but continues to default to `3.0.2`

