### PR TITLE
fixing enum compare to be case insensitive for FFEnumParseString

### DIFF
--- a/pkg/fftypes/enum.go
+++ b/pkg/fftypes/enum.go
@@ -27,15 +27,23 @@ import (
 
 type FFEnum string
 
-var enumValues = map[string][]interface{}{}
+var enumValues = map[string][]string{}
 
 func FFEnumValue(t string, val string) FFEnum {
+	t = strings.ToLower(t)
 	enumValues[t] = append(enumValues[t], val)
 	return FFEnum(val)
 }
 
 func FFEnumValues(t string) []interface{} {
-	return enumValues[t]
+	values := enumValues[strings.ToLower(t)]
+
+	// Convert []string to []interface{} for openapi3.Schema.Enum.
+	result := make([]interface{}, len(values))
+	for i, v := range values {
+		result[i] = v
+	}
+	return result
 }
 
 func (ts FFEnum) String() string {
@@ -74,12 +82,8 @@ func FFEnumParseString(ctx context.Context, t, val string) (FFEnum, error) {
 		return "", i18n.NewError(ctx, i18n.MsgInvalidEnum, t)
 	}
 	for _, possible := range e {
-		possibleStr, ok := possible.(string)
-		if !ok {
-			continue
-		}
-		if strings.EqualFold(possibleStr, val) {
-			return FFEnum(strings.ToLower(possibleStr)), nil
+		if strings.EqualFold(possible, val) {
+			return FFEnum(strings.ToLower(possible)), nil
 		}
 	}
 	return "", i18n.NewError(ctx, i18n.MsgInvalidEnumValue, val, t, e)

--- a/pkg/fftypes/enum.go
+++ b/pkg/fftypes/enum.go
@@ -74,8 +74,12 @@ func FFEnumParseString(ctx context.Context, t, val string) (FFEnum, error) {
 		return "", i18n.NewError(ctx, i18n.MsgInvalidEnum, t)
 	}
 	for _, possible := range e {
-		if possible == strings.ToLower(val) {
-			return FFEnum(strings.ToLower(val)), nil
+		possibleStr, ok := possible.(string)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(possibleStr, val) {
+			return FFEnum(strings.ToLower(possibleStr)), nil
 		}
 	}
 	return "", i18n.NewError(ctx, i18n.MsgInvalidEnumValue, val, t, e)

--- a/pkg/fftypes/enum_test.go
+++ b/pkg/fftypes/enum_test.go
@@ -58,6 +58,18 @@ func TestFFEnumValues(t *testing.T) {
 	assert.Equal(t, []interface{}{"test_enum_val1", "test_enum_val2"}, FFEnumValues("ut"))
 }
 
+func TestFFEnumTypeCaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+	enumVal := FFEnumValue("UT_Case", "case_val1")
+
+	assert.Equal(t, []interface{}{"case_val1"}, FFEnumValues("ut_case"))
+	assert.Equal(t, []interface{}{"case_val1"}, FFEnumValues("UT_CASE"))
+
+	v, err := FFEnumParseString(ctx, "UT_CASE", "case_val1")
+	assert.NoError(t, err)
+	assert.Equal(t, enumVal.Lower(), v)
+}
+
 func TestFFEnumParseString(t *testing.T) {
 	ctx := context.Background()
 	v, err := FFEnumParseString(ctx, "ut", "test_enum_val1")

--- a/pkg/fftypes/enum_test.go
+++ b/pkg/fftypes/enum_test.go
@@ -73,4 +73,10 @@ func TestFFEnumParseString(t *testing.T) {
 	v, err = FFEnumParseString(ctx, "ut", "foobar")
 	assert.Regexp(t, "FF00172", err)
 	assert.Empty(t, v)
+
+	mixed := FFEnumValue("ut_mixed", "Test_Enum_Mixed")
+	v, err = FFEnumParseString(ctx, "ut_mixed", "test_enum_mixed")
+	assert.NoError(t, err)
+	assert.Equal(t, FFEnum("test_enum_mixed"), v)
+	assert.Equal(t, mixed.Lower(), v)
 }


### PR DESCRIPTION
Among all functions apart from `Value()` , the usage of enum values follows a case-insensitive pattern and treats lower case as canonical. 

This PR updates the FFEnumParseString to also be case-insensitive when looking up a string against registered values.
