### PR TITLE
chore: upgrade to Go 1.26.4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.26.4"
 
       - name: Build and Test
         run: make

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger-firefly/common
 
-go 1.23.0
+go 1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/pkg/fswatcher/fswatcher_test.go
+++ b/pkg/fswatcher/fswatcher_test.go
@@ -34,7 +34,7 @@ func TestFileReconcilerE2E(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	tmpDir := t.TempDir()
 
-	filePath := fmt.Sprintf(fmt.Sprintf("%s/test.yaml", tmpDir))
+	filePath := fmt.Sprintf("%s/test.yaml", tmpDir)
 
 	// Create the file
 	os.WriteFile(fmt.Sprintf("%s/test.yaml", tmpDir), []byte(`{"ut_conf": "one"}`), 0664)

--- a/pkg/i18n/errors_test.go
+++ b/pkg/i18n/errors_test.go
@@ -47,7 +47,7 @@ func TestWrapError(t *testing.T) {
 	assert.Equal(t, 500, interface{}(err).(FFError).HTTPStatus())
 	assert.Equal(t, MsgConfigFailed, interface{}(err).(FFError).MessageKey())
 	stackString := interface{}(err).(FFError).StackTrace()
-	fmt.Printf(stackString)
+	fmt.Print(stackString)
 	assert.NotEmpty(t, stackString)
 }
 


### PR DESCRIPTION
Updates common to Go 1.26.4.

- `go.mod` go directive `1.23.0` → `1.26.4`
- CI `go-version` `1.23` → `1.26.4`
- Fix two non-constant format strings in tests that Go 1.26's `vet` now rejects (`pkg/fswatcher/fswatcher_test.go`, `pkg/i18n/errors_test.go`)

golangci-lint (v1.64.8) and all tests pass on Go 1.26.4. Note: bumping the module `go` directive requires downstream consumers of `hyperledger-firefly/common` to build with Go 1.26.4+.
