### PR TITLE
Relax Go to 1.26.0 and toolchain to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hyperledger-firefly/common
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
In order to be less strict on our consumer we should relax the **minimum go version**