### PR TITLE
fixing nil pointer exception for Getters

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -124,7 +124,7 @@ func (c *CCache) GetString(key string) string {
 	if c.enabled {
 		val := c.Get(key)
 		if val != nil {
-			return c.Get(key).(string)
+			return val.(string)
 		}
 	}
 	return ""
@@ -140,7 +140,7 @@ func (c *CCache) GetInt(key string) int {
 	if c.enabled {
 		val := c.Get(key)
 		if val != nil {
-			return c.Get(key).(int)
+			return val.(int)
 		}
 	}
 	return 0
@@ -156,7 +156,7 @@ func (c *CCache) GetInt64(key string) int64 {
 	if c.enabled {
 		val := c.Get(key)
 		if val != nil {
-			return c.Get(key).(int64)
+			return val.(int64)
 		}
 	}
 	return 0

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -146,3 +146,22 @@ func TestGetStrictExpiry(t *testing.T) {
 
 	assert.NotNil(t, cache1.Get("test"))
 }
+
+func TestGetStringConcurrentDelete(t *testing.T) {
+	c := NewUmanagedCache(context.Background(), 1024, time.Minute)
+	c.SetString("key", "value")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 10000; i++ {
+			_ = c.GetString("key")
+		}
+	}()
+
+	for i := 0; i < 10000; i++ {
+		c.SetString("key", "value")
+		c.Delete("key")
+	}
+	<-done
+}


### PR DESCRIPTION
The get methods are not parsing the retrieved value, instead, they call `Get` method to retrieve the value again. 

This caused nil pointer exception when the cache value had expired or been deleted.


```
2026-06-29T12:26:35.548Z] ERROR observed panic (execMapped) 'interface conversion: interface {} is nil, not string': goroutine 433125 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
github.com/kaleido-io/workflow-engine/pkg/enginesdk.execMapped[...].func1()
	/workflow-engine/pkg/enginesdk/txn_handler.go:442 +0x7c
panic({0x1af4920?, 0xc000cc05d0?})
	/usr/local/go/src/runtime/panic.go:783 +0x132
github.com/hyperledger/firefly-common/pkg/cache.(*CCache).GetString(0xc00047bef0, {0xc000c69c00, 0x3a})
	/go/pkg/mod/github.com/hyperledger/firefly-common@v1.5.11-0.20260428164525-50bebf579bab/pkg/cache/cache.go:127 +0x77
```