### PR TITLE
fix: invalid enum on container schemas in OpenAPI generation

### DIFF
--- a/pkg/ffapi/openapi3.go
+++ b/pkg/ffapi/openapi3.go
@@ -230,7 +230,14 @@ type OpenAPITagHandler struct {
 
 func (th *OpenAPITagHandler) HandleFFTags(ctx context.Context, route *Route, name string, tag reflect.StructTag, schema *openapi3.Schema) error {
 	if ffEnum := tag.Get("ffenum"); ffEnum != "" {
-		schema.Enum = fftypes.FFEnumValues(ffEnum)
+		// For a container field (e.g. []FFEnum or map[string]FFEnum) the openapi3gen library
+		// invokes this customizer with the same field tag for both the container schema and its
+		// element schema (array items / map additionalProperties). FFEnum values are always
+		// strings, so the enum belongs only on the string leaf - applying it to the "array" or
+		// "object" container node too produces invalid OpenAPI that strict SDK generators reject.
+		if schema.Type.Is(openapi3.TypeString) {
+			schema.Enum = fftypes.FFEnumValues(ffEnum)
+		}
 	}
 	if ffExtensions := tag.Get("ffschemaext"); ffExtensions != "" {
 		if err := applyFFExtensionsTag(ctx, schema, ffExtensions); err != nil {

--- a/pkg/ffapi/openapi3_test.go
+++ b/pkg/ffapi/openapi3_test.go
@@ -58,10 +58,12 @@ type TestEmbedded1 struct {
 }
 
 type TestStruct2 struct {
-	Enum1    TestEnum         `ffstruct:"ut1" json:"enum1" ffenum:"ut"`
-	String1  string           `ffstruct:"ut1" json:"string1"`
-	String2  string           `ffstruct:"ut1" json:"string2"`
-	JSONAny1 *fftypes.JSONAny `ffstruct:"ut1" json:"jsonAny1,omitempty"`
+	Enum1     TestEnum            `ffstruct:"ut1" json:"enum1" ffenum:"ut"`
+	EnumArray []TestEnum          `ffstruct:"ut1" json:"enumArray" ffenum:"ut"`
+	EnumMap   map[string]TestEnum `ffstruct:"ut1" json:"enumMap" ffenum:"ut"`
+	String1   string              `ffstruct:"ut1" json:"string1"`
+	String2   string              `ffstruct:"ut1" json:"string2"`
+	JSONAny1  *fftypes.JSONAny    `ffstruct:"ut1" json:"jsonAny1,omitempty"`
 }
 
 type TestExtensions struct {
@@ -656,4 +658,61 @@ func TestOpenAPIVersion(t *testing.T) {
 	err := doc.Validate(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, "3.1.1", doc.OpenAPI)
+}
+
+func TestEnumArrayNotAppliedToArraySchema(t *testing.T) {
+	// Regression test: for a slice-of-enum field the enum must be applied only to the
+	// items schema, not the array schema itself. An "enum" on a "type: array" node is
+	// invalid OpenAPI and breaks strict SDK generators.
+	routes := []*Route{
+		{
+			Name:            "EnumArrayTest",
+			Path:            "example1/test",
+			Method:          http.MethodPost,
+			JSONInputValue:  func() interface{} { return &TestStruct1{} },
+			JSONOutputCodes: []int{http.StatusOK},
+		},
+	}
+	doc := NewSwaggerGen(&SwaggerGenOptions{
+		Title:   "UnitTest",
+		Version: "1.0",
+		BaseURL: "http://localhost:12345/api/v1",
+	}).Generate(context.Background(), routes)
+	require.NoError(t, doc.Validate(context.Background()))
+
+	props := doc.Paths.Find("/example1/test").Post.RequestBody.Value.
+		Content.Get("application/json").Schema.Value.Properties
+	struct2 := props["struct2"].Value
+	wantEnum := fftypes.FFEnumValues("ut")
+
+	// 1. Scalar enum (type: string) - enum applied directly on the leaf
+	scalar := struct2.Properties["enum1"].Value
+	assert.True(t, scalar.Type.Is(openapi3.TypeString))
+	assert.Equal(t, wantEnum, scalar.Enum)
+
+	// 2. Array of enum (type: array) - enum ONLY on items, never on the array container
+	enumArray := struct2.Properties["enumArray"].Value
+	assert.True(t, enumArray.Type.Is(openapi3.TypeArray))
+	assert.Nil(t, enumArray.Enum, "enum must not be set on a type:array node")
+	require.NotNil(t, enumArray.Items)
+	assert.True(t, enumArray.Items.Value.Type.Is(openapi3.TypeString))
+	assert.Equal(t, wantEnum, enumArray.Items.Value.Enum)
+
+	// 3. Map of enum (type: object) - enum ONLY on additionalProperties, never on the object container
+	enumMap := struct2.Properties["enumMap"].Value
+	assert.True(t, enumMap.Type.Is(openapi3.TypeObject))
+	assert.Nil(t, enumMap.Enum, "enum must not be set on a type:object node")
+	require.NotNil(t, enumMap.AdditionalProperties.Schema)
+	assert.True(t, enumMap.AdditionalProperties.Schema.Value.Type.Is(openapi3.TypeString))
+	assert.Equal(t, wantEnum, enumMap.AdditionalProperties.Schema.Value.Enum)
+
+	// 4. Non-enum fields of every kind must never gain an enum
+	for name, ref := range struct2.Properties {
+		switch name {
+		case "enum1", "enumArray", "enumMap":
+			continue
+		default:
+			assert.Nil(t, ref.Value.Enum, "unexpected enum on non-enum field %q", name)
+		}
+	}
 }


### PR DESCRIPTION
The ffenum tag handler applied schema.Enum unconditionally. For container fields ([]FFEnum, map[string]FFEnum) the openapi3gen library invokes the schema customizer with the same field tag for both the container schema and its element schema, so the enum was stamped on the "array"/"object" container node as well as the string leaf. An enum on a type:array or type:object node is invalid OpenAPI and is rejected by strict SDK generators (kin-openapi's own Validate() does not catch it).