### PR TITLE
Fix swagger serve to have correct max descriptions

### DIFF
--- a/pkg/ffapi/apiserver.go
+++ b/pkg/ffapi/apiserver.go
@@ -145,6 +145,9 @@ func NewAPIServer[T any](ctx context.Context, options APIServerOptions[T]) APISe
 			SupportFieldRedaction:      options.SupportFieldRedaction,
 			ExportComponentOpts:        options.SwaggerExportComponentOpts,
 			AdditionalSchemaCustomizer: options.SwaggerAdditionalSchemaCustomizer,
+			APIDefaultFilterLimit:      options.APIConfig.GetString(ConfAPIDefaultFilterLimit),
+			APIMaxFilterLimit:          options.APIConfig.GetUint(ConfAPIMaxFilterLimit),
+			APIMaxFilterSkip:           options.APIConfig.GetUint(ConfAPIMaxFilterSkip),
 		},
 	}
 	if as.FavIcon16 == nil {

--- a/pkg/ffapi/apiserver_test.go
+++ b/pkg/ffapi/apiserver_test.go
@@ -352,6 +352,29 @@ func TestAPIServerSwaggerJSON(t *testing.T) {
 	assert.Regexp(t, "application/json", res.Header().Get("content-type"))
 }
 
+func TestAPIServerSwaggerFilterLimitsFromConfig(t *testing.T) {
+	_, as, done := newTestAPIServer(t, false)
+	defer done()
+
+	assert.Equal(t, "25", as.baseSwaggerGenOptions.APIDefaultFilterLimit)
+	assert.Equal(t, uint(100), as.baseSwaggerGenOptions.APIMaxFilterLimit)
+	assert.Equal(t, uint(100000), as.baseSwaggerGenOptions.APIMaxFilterSkip)
+
+	doc := NewSwaggerGen(&as.baseSwaggerGenOptions).Generate(context.Background(), []*Route{{
+		Name:            "getThings",
+		Path:            "things",
+		Method:          http.MethodGet,
+		Description:     "list things",
+		FilterFactory:   TestQueryFactory,
+		JSONOutputValue: func() interface{} { return &sampleOutput{} },
+		JSONOutputCodes: []int{http.StatusOK},
+	}})
+	b, err := json.Marshal(doc)
+	assert.NoError(t, err)
+	assert.Contains(t, string(b), "The maximum number of records to return (max: 100)")
+	assert.Contains(t, string(b), "The number of records to skip (max: 100,000)")
+}
+
 func TestAPIServerSwaggerYAML(t *testing.T) {
 	_, as, done := newTestAPIServer(t, true)
 	defer done()


### PR DESCRIPTION
I found a case where serving live Swagger on `/api` the descriptions for the max on the limit/skip were `0` rather than the actual runtime defaults.

The problem was the defaults were not being passed down to the swagger generator layer.